### PR TITLE
Ulepszenie zgłębiania wiedzy

### DIFF
--- a/Arkadia.xml
+++ b/Arkadia.xml
@@ -1877,6 +1877,42 @@
 					</Trigger>
 				</TriggerGroup>
 				<TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+					<name>knowledge</name>
+					<script></script>
+					<triggerType>0</triggerType>
+					<conditonLineDelta>0</conditonLineDelta>
+					<mStayOpen>0</mStayOpen>
+					<mCommand></mCommand>
+					<packageName></packageName>
+					<mFgColor>#ff0000</mFgColor>
+					<mBgColor>#ffff00</mBgColor>
+					<mSoundFile></mSoundFile>
+					<colorTriggerFgColor>#000000</colorTriggerFgColor>
+					<colorTriggerBgColor>#000000</colorTriggerBgColor>
+					<regexCodeList />
+					<regexCodePropertyList />
+					<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+						<name>zglebiaj</name>
+						<script>trigger_func_skrypty_misc_knowledge_O_czym_wiedze_checesz_zglebiac()</script>
+						<triggerType>0</triggerType>
+						<conditonLineDelta>0</conditonLineDelta>
+						<mStayOpen>0</mStayOpen>
+						<mCommand></mCommand>
+						<packageName></packageName>
+						<mFgColor>#ff0000</mFgColor>
+						<mBgColor>#ffff00</mBgColor>
+						<mSoundFile></mSoundFile>
+						<colorTriggerFgColor>#000000</colorTriggerFgColor>
+						<colorTriggerBgColor>#000000</colorTriggerBgColor>
+						<regexCodeList>
+							<string>^Wiedze o czym chcesz zglebiac\? (.*)$</string>
+						</regexCodeList>
+						<regexCodePropertyList>
+							<integer>1</integer>
+						</regexCodePropertyList>
+					</Trigger>
+				</TriggerGroup>
+				<TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 					<name>calendar</name>
 					<script></script>
 					<triggerType>0</triggerType>
@@ -23791,13 +23827,27 @@
 					<packageName></packageName>
 					<regex>^um(|iejetnosci)$</regex>
 				</Alias>
-				<Alias isActive="yes" isFolder="no">
+				<AliasGroup isActive="yes" isFolder="yes">
 					<name>wiedza</name>
-					<script>alias_func_skrypty_misc_wiedza()</script>
+					<script></script>
 					<command></command>
 					<packageName></packageName>
-					<regex>^(wiedza)$</regex>
-				</Alias>
+					<regex></regex>
+					<Alias isActive="yes" isFolder="no">
+						<name>wiedza</name>
+						<script>alias_func_skrypty_misc_wiedza()</script>
+						<command></command>
+						<packageName></packageName>
+						<regex>^(wiedza)$</regex>
+					</Alias>
+					<Alias isActive="yes" isFolder="no">
+						<name>zglebiaj</name>
+						<script>alias_func_skrypty_misc_zglebiaj_wiedze()</script>
+						<command></command>
+						<packageName></packageName>
+						<regex>^zglebiaj\s+(?:wiedze\s+)?(\d+)$</regex>
+					</Alias>
+				</AliasGroup>
 				<Alias isActive="yes" isFolder="no">
 					<name>jezyki</name>
 					<script>alias_func_skrypty_misc_jezyki()</script>

--- a/Arkadia.xml
+++ b/Arkadia.xml
@@ -1891,7 +1891,7 @@
 					<colorTriggerBgColor>#000000</colorTriggerBgColor>
 					<regexCodeList />
 					<regexCodePropertyList />
-					<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
+					<Trigger isActive="no" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 						<name>zglebiaj</name>
 						<script>trigger_func_skrypty_misc_knowledge_O_czym_wiedze_checesz_zglebiac()</script>
 						<triggerType>0</triggerType>
@@ -23845,7 +23845,7 @@
 						<script>alias_func_skrypty_misc_zglebiaj_wiedze()</script>
 						<command></command>
 						<packageName></packageName>
-						<regex>^zglebiaj\s+(?:wiedze\s+)?(\d+)$</regex>
+						<regex>^zglebiaj(?:\s+wiedze\s+)?\s*(\d*)$</regex>
 					</Alias>
 				</AliasGroup>
 				<Alias isActive="yes" isFolder="no">

--- a/skrypty/misc/knowledge.lua
+++ b/skrypty/misc/knowledge.lua
@@ -19,3 +19,41 @@ function misc:knowledge_replace(text)
     resetFormat()
 end
 
+last_knowledge = nil
+
+-- rozbija output dostepnych do zglebiania wiedzy na linie
+function misc:zglebiaj_replace(text)
+    selectString(text, 1)
+    replace("\n")
+
+    text = string.gsub(text, "czy o ([^?]*)?", ", o %1")
+    local available = string.split(text, ",")
+    last_knowledge = available
+    for i,var in pairs(available) do
+        var = string.lower(string.trim(var))
+        cecho(''..i..'. '..var..'\n')
+    end
+end
+
+function misc:zglebiaj_wiedze(index)
+    index = tonumber(index)
+    if last_knowledge == nil then
+        send('zglebiaj')
+        return
+    end
+
+    local name = last_knowledge[index]
+    if name == nil then
+        cecho("<orange>Nie odnalazlem wiedzy o tym indeksie. Sprobuj podac pelna nazwe.\n")
+        return
+    end
+    send('zglebiaj wiedze '..name)
+end
+
+function alias_func_skrypty_misc_zglebiaj_wiedze()
+    misc:zglebiaj_wiedze(tonumber(matches[2]))
+end
+
+function trigger_func_skrypty_misc_knowledge_O_czym_wiedze_checesz_zglebiac()
+    misc:zglebiaj_replace(matches[2])
+end

--- a/skrypty/misc/knowledge.lua
+++ b/skrypty/misc/knowledge.lua
@@ -33,6 +33,8 @@ function misc:zglebiaj_replace(text)
         var = string.lower(string.trim(var))
         cecho(''..i..'. '..var..'\n')
     end
+
+    disableTrigger("zglebiaj")
 end
 
 function misc:zglebiaj_wiedze(index)
@@ -51,7 +53,14 @@ function misc:zglebiaj_wiedze(index)
 end
 
 function alias_func_skrypty_misc_zglebiaj_wiedze()
-    misc:zglebiaj_wiedze(tonumber(matches[2]))
+    local number = string.trim(matches[2])
+    if (number == nil or number == '') then
+        enableTrigger("zglebiaj")
+        send('zglebiaj')
+        tempTimer(1, [[ disableTrigger("zglebiaj") ]])
+    else
+        misc:zglebiaj_wiedze(tonumber(number))
+    end  
 end
 
 function trigger_func_skrypty_misc_knowledge_O_czym_wiedze_checesz_zglebiac()


### PR DESCRIPTION
Ułatwienia do zglębiania wiedzy w bibliotekach.

## Jak działało dotychczas
Komenda `zglebiaj` wypisuje dostępne do zgłębiania tematy w jednej linii i wymaga podania dokładniej takiej samej nazwy żeby daną wiedzę zgłębić.

![image](https://user-images.githubusercontent.com/1384600/81510277-e7722a00-9310-11ea-81ab-db367ac6f07c.png)

## Jak działa po zmianach
Rezultat komendy jest rozdzielany na wiersze oraz numerowany. Dostępny jest alias który pozwala zgłębiać wiedzę o podanym numerze (bez podawania pełnej nazwy). 

![image](https://user-images.githubusercontent.com/1384600/81510290-f6f17300-9310-11ea-8b22-d7777a98bacd.png)

Poprzednia (pełna) komenda dalej działa, czyli można dalej użyć `zglebiaj wiedze o goblinoidach`