### PR TITLE
Ui fix

### DIFF
--- a/skrypty/ui.lua
+++ b/skrypty/ui.lua
@@ -240,8 +240,6 @@ end
 
 scripts.ui.states_window_navbar_str = ""
 
-tempTimer(2.348, function() scripts.ui:init_states_window_navbar() end)
-
 function alias_func_skrypty_ui_restart_ui()
     scripts.ui:setup()
 end

--- a/skrypty/ui/ui.lua
+++ b/skrypty/ui/ui.lua
@@ -8,39 +8,25 @@ function scripts.ui:get_bind_color_backward_compatible()
     return color
 end
 
-function scripts.ui:run_setup()
-    tempTimer(0.5, function()
-        scripts.ui:setup()
-    end)
-end
-
 function scripts.ui:setup()
     setBorderBottom(scripts.ui.footer_height)
-    --scripts.ui.main_width, scripts.ui.main_height = getMainWindowSize()
 
     if not scripts.ui.map_loaded then
-        --local main = Geyser.Container:new({x=0,y=0,width="100%",height="100%",name="mapper container"})
-
-        --local mapper = Geyser.Mapper:new({
-        --  name = "mapper",
-        --  x = "70%", y = 0, -- edit here if you want to move it
-        --  width = "30%", height = "50%"
-        --}, main)
         if amap and amap.curr and amap.curr.id then
             centerview(amap.curr.id)
         end
         scripts.ui.map_loaded = true
     end
 
-    --scripts.ui.real_footer_height = scripts.ui.footer_height
-    --scripts.ui.real_footer_width = scripts.ui.footer_width/100 * scripts.ui.main_width
-
     scripts.ui:setup_states_window()
     scripts.ui:setup_talk_window()
     
     scripts.ui:setup_footer()
     scripts.ui:setup_footer_closed()
+
+    scripts.ui:init_states_window_navbar()
+
     raiseEvent("uiReady")
 end
 
-scripts.ui:run_setup()
+registerAnonymousEventHandler("sysLoadEvent", function() scripts.ui:setup() end)


### PR DESCRIPTION
podczas ładowania UI czasami zdarza się, że timer odpala się  zanim się wszystkie załadują (pojawiają się błędy, że metody `setup_states_window` lub `init_states_window_navbar` nie istnieją)
Problem pojawia się nieregularnie, ale wydaje mi się, że to powinno go rozwiązać.