### PR TITLE
Aliasy do pokazania innym graczom swojego zmęczenia/obciązenia/many etc. 

### DIFF
--- a/Arkadia.xml
+++ b/Arkadia.xml
@@ -24528,6 +24528,55 @@
 					<packageName></packageName>
 					<regex>^/staz ?(.*)</regex>
 				</Alias>
+				<AliasGroup isActive="yes" isFolder="yes">
+					<name>/zamelduj</name>
+					<script></script>
+					<command></command>
+					<packageName></packageName>
+					<regex>^/zam</regex>
+					<Alias isActive="yes" isFolder="no">
+						<name>mane</name>
+						<script>alias_func_skrypty_character_state_reporting_mana()</script>
+						<command></command>
+						<packageName></packageName>
+						<regex>^/zam(?:elduj )?man(?:e)?$</regex>
+					</Alias>
+					<Alias isActive="yes" isFolder="no">
+						<name>obciazenie</name>
+						<script>alias_func_skrypty_character_state_reporting_encumbrance()</script>
+						<command></command>
+						<packageName></packageName>
+						<regex>^/zam(?:elduj )?obc(?:iazenie)?$</regex>
+					</Alias>
+					<Alias isActive="yes" isFolder="no">
+						<name>pragnienie</name>
+						<script>alias_func_skrypty_character_state_reporting_soaked()</script>
+						<command></command>
+						<packageName></packageName>
+						<regex>^/zam(?:elduj )?pra(?:gnienie)?$</regex>
+					</Alias>
+					<Alias isActive="yes" isFolder="no">
+						<name>upicie</name>
+						<script>alias_func_skrypty_character_state_reporting_intox()</script>
+						<command></command>
+						<packageName></packageName>
+						<regex>^/zam(?:elduj )?upi(?:cie)?$</regex>
+					</Alias>
+					<Alias isActive="yes" isFolder="no">
+						<name>glod</name>
+						<script>alias_func_skrypty_character_state_reporting_stuffed()</script>
+						<command></command>
+						<packageName></packageName>
+						<regex>^/zam(?:elduj )?glo(?:d)?$</regex>
+					</Alias>
+					<Alias isActive="yes" isFolder="no">
+						<name>zmeczenie</name>
+						<script>alias_func_skrypty_character_state_reporting_fatigue()</script>
+						<command></command>
+						<packageName></packageName>
+						<regex>^/zam(?:elduj )?zme(?:czenie)?$</regex>
+					</Alias>
+				</AliasGroup>
 			</AliasGroup>
 			<AliasGroup isActive="yes" isFolder="yes">
 				<name>mail</name>

--- a/config.md
+++ b/config.md
@@ -1476,3 +1476,188 @@ Ustawienie nie działa na linie już wcześniej wyświetlone.
 Dostępne wartości:
 * `true` - włączone
 * `false` - wyłączone
+
+
+## `scripts.ui.auto_wrap_main_window.enabled`
+
+Długość linii (miejsce jej łamania dokładniej mówiąc) w głównym oknie będzie zależna od jego szerokości.
+Ustawienie szczególnie użyteczne dla osób przerzucających okno na rózne wielkościowo monitory. 
+Ustawienie nie działa na linie już wcześniej wyświetlone.
+
+Dostępne wartości:
+* `true` - włączone
+* `false` - wyłączone
+
+## `scripts.character.state_reporting.<cecha>.<wartosc_liczbowa>`
+
+Ustawia komendy które mają być wysyłane przy meldowaniu stanu postaci. 
+
+Niektóre statystyki postaci nie są widoczne z zewnątrz - np. poziom zmęczenia, obciązenia, głodu, 
+pragnienia, upicie czy many. Aby ułatwić przekazywanie tych wartości innym graczom została dodana komenda
+`/zamelduj <co>` która uruchamia skonfigurawaną komendę mającą poinformować innych o stanie twojej postaci. 
+
+Przykładowo:
+
+```
+> /zamelduj zmeczenie
+Mowisz: Troche zmeczony.
+```
+
+lub w skróconej formie:
+
+```
+> /zamzme
+Mowisz: Troche zmeczony.
+```
+
+Bieżąca wartość stystyki brana jest z automatycznie z GMCP. Dozwolone wartosci ustawienia to lista komend do wykonania. 
+Za każdym kolejnym wywołaniem wysyłana jest kolejna komenda z tej listy. Jeżeli chcesz wysłać dwie lub więcej komend
+na raz musisz podać je jako jedną wartość i oddzielić znakiem separatora komend.
+
+Przykładowo dla konfiguracji:
+
+```json
+"scripts.character.state_reporting.fatigue.options_male.0": [
+    "usmiechnij sie dumnie;'W pelni wypoczety.", 
+    "machnij reka lekko;'W pelni sil."
+],
+```
+
+użycie będzie wyglądało następująco:
+
+```
+/zamzme
+Usmiechasz sie dumnie.
+Mowisz: W pelni wypoczety.
+
+/zamzme
+Machasz reka lekko.
+Mowisz: W pelni sil.
+
+/zamzme
+Usmiechasz sie dumnie.
+Mowisz: W pelni wypoczety.
+```
+
+Ustawienia przyjmują wartości w formie męskiej i żeńskiej. Używana jest tylko wartość pasująca do płci
+twojej postaci.
+
+### Przykład: zmęcznie (Komenda `/zamelduj zmeczenie` lub `/zamzme`):
+
+```
+"scripts.character.state_reporting.fatigue.options_male.0": ["'W pelni wypoczety.", "'W pelni sil."],
+"scripts.character.state_reporting.fatigue.options_male.1": ["'Wypoczety."],
+"scripts.character.state_reporting.fatigue.options_male.2": ["'Troche zmeczony."],
+"scripts.character.state_reporting.fatigue.options_male.3": ["'Zmeczony."],
+"scripts.character.state_reporting.fatigue.options_male.4": ["'Bardzo zmeczony."],
+"scripts.character.state_reporting.fatigue.options_male.5": ["'Nieco wyczerpany."],
+"scripts.character.state_reporting.fatigue.options_male.6": ["'Wyczerpany."],
+"scripts.character.state_reporting.fatigue.options_male.7": ["'Bardzo wyczerpany."],
+"scripts.character.state_reporting.fatigue.options_male.8": ["'Wycienczony."],
+"scripts.character.state_reporting.fatigue.options_male.9": ["'Calkowicie wycienczony."],
+"scripts.character.state_reporting.fatigue.options_female.0": ["'W pelni wypoczeta.", "'W pelni sil."],
+"scripts.character.state_reporting.fatigue.options_female.1": ["'Wypoczeta."],
+"scripts.character.state_reporting.fatigue.options_female.2": ["'Troche zmeczona."],
+"scripts.character.state_reporting.fatigue.options_female.3": ["'Zmeczona."],
+"scripts.character.state_reporting.fatigue.options_female.4": ["'Bardzo zmeczona."],
+"scripts.character.state_reporting.fatigue.options_female.5": ["'Nieco wyczerpana."],
+"scripts.character.state_reporting.fatigue.options_female.6": ["'Wyczerpana"],
+"scripts.character.state_reporting.fatigue.options_female.7": ["'Bardzo wyczerpana."],
+"scripts.character.state_reporting.fatigue.options_female.8": ["'Wycienczona."],
+"scripts.character.state_reporting.fatigue.options_female.9": ["'Calkowicie wycienczona."],
+```
+
+### Przykład: obciążenie (Komenda `/zamelduj obciazenie` lub `/zamobc`):
+
+```
+"scripts.character.state_reporting.encumbrance.options_male.0": ["'Brak obciazenia"],
+"scripts.character.state_reporting.encumbrance.options_male.1": ["'Wadzi mi troche."],
+"scripts.character.state_reporting.encumbrance.options_male.2": ["'Daje mi sie we znaki."],
+"scripts.character.state_reporting.encumbrance.options_male.3": ["'Ekwipunek jest dosc klopotliwy."],
+"scripts.character.state_reporting.encumbrance.options_male.4": ["'Ekwipunek jest wyjatkowo ciezki."],
+"scripts.character.state_reporting.encumbrance.options_male.5": ["'Ekwipunek jest niemilosiernie ciezki"],
+"scripts.character.state_reporting.encumbrance.options_male.6": ["'Ekwipunek przygniata mnie do ziemi."],
+"scripts.character.state_reporting.encumbrance.options_female.0": ["'Brak obciazenia"],
+"scripts.character.state_reporting.encumbrance.options_female.1": ["'Wadzi mi troche."],
+"scripts.character.state_reporting.encumbrance.options_female.2": ["'Daje mi sie we znaki."],
+"scripts.character.state_reporting.encumbrance.options_female.3": ["'Ekwipunek jest dosc klopotliwy."],
+"scripts.character.state_reporting.encumbrance.options_female.4": ["'Ekwipunek jest wyjatkowo ciezki."],
+"scripts.character.state_reporting.encumbrance.options_female.5": ["'Ekwipunek jest niemilosiernie ciezki"],
+"scripts.character.state_reporting.encumbrance.options_female.6": ["'Ekwipunek przygniata mnie do ziemi."],
+```
+
+### Przykład: głód (Komenda `/zamelduj glod` lub `/zamglo`):
+
+```
+"scripts.character.state_reporting.stuffed.options_male.0": ["'Bardzo glodny"],
+"scripts.character.state_reporting.stuffed.options_male.1": ["'Glodny."],
+"scripts.character.state_reporting.stuffed.options_male.2": ["'Najedzony."],
+"scripts.character.state_reporting.stuffed.options_male.3": ["'Bardzo najedzony."],
+"scripts.character.state_reporting.stuffed.options_female.0": ["'Bardzo glodna"],
+"scripts.character.state_reporting.stuffed.options_female.1": ["'Glodna."],
+"scripts.character.state_reporting.stuffed.options_female.2": ["'Najedzona."],
+"scripts.character.state_reporting.stuffed.options_female.3": ["'Bardzo najedzona."],
+```
+
+### Przykład: głód (Komenda `/zamelduj pragnienie` lub `/zampra`):
+
+```
+"scripts.character.state_reporting.soaked.options_male.0": ["'Bardzo chce mi sie pic", "'Bardzo spragniony"],
+"scripts.character.state_reporting.soaked.options_male.1": ["'Chce mi sie pic.", "'Spragniony"],
+"scripts.character.state_reporting.soaked.options_male.2": ["'Troche chce mi sie pic.", "'Troche spragniony"],
+"scripts.character.state_reporting.soaked.options_male.3": ["'Nie chce mi sie pic."],
+"scripts.character.state_reporting.soaked.options_female.0": ["'Bardzo chce mi sie pic", "'Bardzo spragniona"],
+"scripts.character.state_reporting.soaked.options_female.1": ["'Chce mi sie pic.", "'Spragniona"],
+"scripts.character.state_reporting.soaked.options_female.2": ["'Troche chce mi sie pic.", "'Troche spragniona"],
+"scripts.character.state_reporting.soaked.options_female.3": ["'Nie chce mi sie pic."],
+```
+
+### Przykład: głód (Komenda `/zamelduj upicie` lub `/zamupi`):
+
+```
+"scripts.character.state_reporting.intox.options_male.0": ["'Trzezwy"],
+"scripts.character.state_reporting.intox.options_male.1": ["'Pochmielony."],
+"scripts.character.state_reporting.intox.options_male.2": ["'Lekko podpity."],
+"scripts.character.state_reporting.intox.options_male.3": ["'Podpity."],
+"scripts.character.state_reporting.intox.options_male.4": ["'Wstawiony."],
+"scripts.character.state_reporting.intox.options_male.5": ["'Mocno wstawiony."],
+"scripts.character.state_reporting.intox.options_male.6": ["'Pijany."],
+"scripts.character.state_reporting.intox.options_male.7": ["'Schlany."],
+"scripts.character.state_reporting.intox.options_male.8": ["'Napruty."],
+"scripts.character.state_reporting.intox.options_male.9": ["'Nawalony."],
+"scripts.character.state_reporting.intox.options_male.10": ["'Pijany jak bela."],
+"scripts.character.state_reporting.intox.options_female.0": ["'Trzezwa"],
+"scripts.character.state_reporting.intox.options_female.1": ["'Pochmielona."],
+"scripts.character.state_reporting.intox.options_female.2": ["'Lekko podpita."],
+"scripts.character.state_reporting.intox.options_female.3": ["'Podpita."],
+"scripts.character.state_reporting.intox.options_female.4": ["'Wstawiona."],
+"scripts.character.state_reporting.intox.options_female.5": ["'Mocno wstawiona."],
+"scripts.character.state_reporting.intox.options_female.6": ["'Pijana."],
+"scripts.character.state_reporting.intox.options_female.7": ["'Schlana."],
+"scripts.character.state_reporting.intox.options_female.8": ["'Napruta."],
+"scripts.character.state_reporting.intox.options_female.9": ["'Nawalona."],
+"scripts.character.state_reporting.intox.options_female.10": ["'Pijana jak bela."],
+```
+
+### Przykład: głód (Komenda `/zamelduj mane` lub `/zamman`):
+
+```
+"scripts.character.state_reporting.mana.options_male.0": ["'Jestem u kresu sil mentalnych"],
+"scripts.character.state_reporting.mana.options_male.1": ["'Jestem wykonczony mentalnie."],
+"scripts.character.state_reporting.mana.options_male.2": ["'Jestem wyczerpana mentalnie."],
+"scripts.character.state_reporting.mana.options_male.3": ["'Jestem w zlej kondycji mentalnej."],
+"scripts.character.state_reporting.mana.options_male.4": ["'Jestem bardzo zmeczony mentalnie."],
+"scripts.character.state_reporting.mana.options_male.5": ["'Jestem zmeczony mentalnie."],
+"scripts.character.state_reporting.mana.options_male.6": ["'Jestem oslabiony mentalnie."],
+"scripts.character.state_reporting.mana.options_male.7": ["'Jestem lekko oslabony mentalnie."],
+"scripts.character.state_reporting.mana.options_male.8": ["'Jestem w pelni sil mentalnych."],
+"scripts.character.state_reporting.mana.options_female.0": ["'Jestem u kresu sil mentalnych"],
+"scripts.character.state_reporting.mana.options_female.1": ["'Jestem wykonczona mentalnie."],
+"scripts.character.state_reporting.mana.options_female.2": ["'Jestem wyczerpana mentalnie."],
+"scripts.character.state_reporting.mana.options_female.3": ["'Jestem w zlej kondycji mentalnej."],
+"scripts.character.state_reporting.mana.options_female.4": ["'Jestem bardzo zmeczona mentalnie."],
+"scripts.character.state_reporting.mana.options_female.5": ["'Jestem zmeczona mentalnie."],
+"scripts.character.state_reporting.mana.options_female.6": ["'Jestem oslabiona mentalnie."],
+"scripts.character.state_reporting.mana.options_female.7": ["'Jestem lekko oslabona mentalnie."],
+"scripts.character.state_reporting.mana.options_female.8": ["'Jestem w pelni sil mentalnych."],
+```

--- a/scriptsList.lua
+++ b/scriptsList.lua
@@ -66,6 +66,7 @@ return {
     "skrypty/character/character_gmcp_updater",
     "skrypty/character/combat_state",
     "skrypty/character/profession",
+    "skrypty/character/state_reporting",
     "skrypty/config/fixers",
     "skrypty/config/core",
     "skrypty/config/alias",

--- a/skrypty/character/state_reporting.lua
+++ b/skrypty/character/state_reporting.lua
@@ -134,22 +134,6 @@ scripts.character.state_reporting = scripts.character.state_reporting or {
     },
 }
 
-function scripts.character.state_reporting:init()
-    -- self.cfg_handler = scripts.event_register:force_register_event_handler(self.cfg_handler, "setVar", function (_, var, val)
-    --     if var == "scripts.character.state_reporting" then
-    --         if val then
-    --             self.handler = scripts.event_register:register_event_handler("gmcp.gmcp_msgs", function()
-    --                 if gmcp.gmcp_msgs.type == "room.exits" then
-    --                     self:show_compass_rose()
-    --                 end
-    --             end)
-    --         else
-    --             scripts.event_register:kill_event_handler(self.handler)
-    --         end
-    --     end
-    -- end)
-end
-
 function scripts.character.state_reporting.say_state(property)
 
     local config = scripts.character.state_reporting[property];

--- a/skrypty/character/state_reporting.lua
+++ b/skrypty/character/state_reporting.lua
@@ -1,0 +1,208 @@
+scripts.character.state_reporting = scripts.character.state_reporting or {
+    last_index = 1,
+
+    fatigue = {
+        options_male = {
+            ["0"] = {"'W pelni wypoczety.", "'W pelni sil."},
+            ["1"] = {"'Wypoczety."},
+            ["2"] = {"'Troche zmeczony."},
+            ["3"] = {"'Zmeczony."},
+            ["4"] = {"'Bardzo zmeczony."},
+            ["5"] = {"'Nieco wyczerpany."},
+            ["6"] = {"'Wyczerpany."},
+            ["7"] = {"'Bardzo wyczerpany."},
+            ["8"] = {"'Wycienczony."},
+            ["9"] = {"'Calkowicie wycienczony."},
+        },
+        options_female = {
+            ["0"] = {"'W pelni wypoczeta.", "'W pelni sil."},
+            ["1"] = {"'Wypoczeta."},
+            ["2"] = {"'Troche zmeczona."},
+            ["3"] = {"'Zmeczona."},
+            ["4"] = {"'Bardzo zmeczona."},
+            ["5"] = {"'Nieco wyczerpana."},
+            ["6"] = {"'Wyczerpana"},
+            ["7"] = {"'Bardzo wyczerpana."},
+            ["8"] = {"'Wycienczona."},
+            ["9"] = {"'Calkowicie wycienczona."},
+        }
+    },
+ 
+    encumbrance = {
+        options_male = {
+            ["0"] = {"'Brak obciazenia"},
+            ["1"] = {"'Wadzi mi troche."},
+            ["2"] = {"'Daje mi sie we znaki."},
+            ["3"] = {"'Ekwipunek jest dosc klopotliwy."},
+            ["4"] = {"'Ekwipunek jest wyjatkowo ciezki."},
+            ["5"] = {"'Ekwipunek jest niemilosiernie ciezki"},
+            ["6"] = {"'Ekwipunek przygniata mnie do ziemi."},
+        },
+        options_female = {
+            ["0"] = {"'Brak obciazenia"},
+            ["1"] = {"'Wadzi mi troche."},
+            ["2"] = {"'Daje mi sie we znaki."},
+            ["3"] = {"'Ekwipunek jest dosc klopotliwy."},
+            ["4"] = {"'Ekwipunek jest wyjatkowo ciezki."},
+            ["5"] = {"'Ekwipunek jest niemilosiernie ciezki"},
+            ["6"] = {"'Ekwipunek przygniata mnie do ziemi."},
+        }
+    },
+
+    stuffed = {
+        options_male = {
+            ["0"] = {"'Bardzo glodny"},
+            ["1"] = {"'Glodny."},
+            ["2"] = {"'Najedzony."},
+            ["3"] = {"'Bardzo najedzony."},
+        },
+        options_female = {
+            ["0"] = {"'Bardzo glodna"},
+            ["1"] = {"'Glodna."},
+            ["2"] = {"'Najedzona."},
+            ["3"] = {"'Bardzo najedzona."},
+        }
+    },
+
+    soaked = {
+        options_male = {
+            ["0"] = {"'Bardzo chce mi sie pic", "'Bardzo spragniony"},
+            ["1"] = {"'Chce mi sie pic.", "'Spragniony"},
+            ["2"] = {"'Troche chce mi sie pic.", "'Troche spragniony"},
+            ["3"] = {"'Nie chce mi sie pic."},
+        },
+        options_female = {
+            ["0"] = {"'Bardzo chce mi sie pic", "'Bardzo spragniona"},
+            ["1"] = {"'Chce mi sie pic.", "'Spragniona"},
+            ["2"] = {"'Troche chce mi sie pic.", "'Troche spragniona"},
+            ["3"] = {"'Nie chce mi sie pic."},
+        }
+    },
+
+    intox = {
+        options_male = {
+            ["0"] = {"'Trzezwy"},
+            ["1"] = {"'Pochmielony."},
+            ["2"] = {"'Lekko podpity."},
+            ["3"] = {"'Podpity."},
+            ["4"] = {"'Wstawiony."},
+            ["5"] = {"'Mocno wstawiony."},
+            ["6"] = {"'Pijany."},
+            ["7"] = {"'Schlany."},
+            ["8"] = {"'Napruty."},
+            ["9"] = {"'Nawalony."},
+            ["10"] = {"'Pijany jak bela."},
+        },
+        options_female = {
+            ["0"] = {"'Trzezwa"},
+            ["1"] = {"'Pochmielona."},
+            ["2"] = {"'Lekko podpita."},
+            ["3"] = {"'Podpita."},
+            ["4"] = {"'Wstawiona."},
+            ["5"] = {"'Mocno wstawiona."},
+            ["6"] = {"'Pijana."},
+            ["7"] = {"'Schlana."},
+            ["8"] = {"'Napruta."},
+            ["9"] = {"'Nawalona."},
+            ["10"] = {"'Pijana jak bela."},
+        }
+    },
+
+    mana = {
+        options_male = {
+            ["0"] = {"'Jestem u kresu sil mentalnych"},
+            ["1"] = {"'Jestem wykonczony mentalnie."},
+            ["2"] = {"'Jestem wyczerpana mentalnie."},
+            ["3"] = {"'Jestem w zlej kondycji mentalnej."},
+            ["4"] = {"'Jestem bardzo zmeczony mentalnie."},
+            ["5"] = {"'Jestem zmeczony mentalnie."},
+            ["6"] = {"'Jestem oslabiony mentalnie."},
+            ["7"] = {"'Jestem lekko oslabony mentalnie."},
+            ["8"] = {"'Jestem w pelni sil mentalnych."},
+        },
+        options_female = {
+            ["0"] = {"'Jestem u kresu sil mentalnych"},
+            ["1"] = {"'Jestem wykonczona mentalnie."},
+            ["2"] = {"'Jestem wyczerpana mentalnie."},
+            ["3"] = {"'Jestem w zlej kondycji mentalnej."},
+            ["4"] = {"'Jestem bardzo zmeczona mentalnie."},
+            ["5"] = {"'Jestem zmeczona mentalnie."},
+            ["6"] = {"'Jestem oslabiona mentalnie."},
+            ["7"] = {"'Jestem lekko oslabona mentalnie."},
+            ["8"] = {"'Jestem w pelni sil mentalnych."},
+        }
+    },
+}
+
+function scripts.character.state_reporting:init()
+    -- self.cfg_handler = scripts.event_register:force_register_event_handler(self.cfg_handler, "setVar", function (_, var, val)
+    --     if var == "scripts.character.state_reporting" then
+    --         if val then
+    --             self.handler = scripts.event_register:register_event_handler("gmcp.gmcp_msgs", function()
+    --                 if gmcp.gmcp_msgs.type == "room.exits" then
+    --                     self:show_compass_rose()
+    --                 end
+    --             end)
+    --         else
+    --             scripts.event_register:kill_event_handler(self.handler)
+    --         end
+    --     end
+    -- end)
+end
+
+function scripts.character.state_reporting.say_state(property)
+
+    local config = scripts.character.state_reporting[property];
+    if not config then 
+        debugc("Brak opcji scripts.character.state_reporting." .. property)
+        return
+    end
+
+    local command;
+    if gmcp.char.state[property] and gmcp.char.info.gender then
+        local options = config['options_'..gmcp.char.info.gender];
+        local value = gmcp.char.state[property]
+        local labels = options["" .. value]
+
+        if #labels == 0 then
+            debugc("Brak etykiet dla wartosci " .. property.. "=" .. value)
+            command = nil
+        else 
+            local index = scripts.character.state_reporting.last_index;
+            index = (index - 1) % #labels + 1
+            command = labels[index];
+            scripts.character.state_reporting.last_index = index + 1;
+        end
+    end
+
+    if command then
+        send(command, false)
+    end
+end
+
+
+function alias_func_skrypty_character_state_reporting_mana()
+    scripts.character.state_reporting.say_state("mana")
+end
+
+function alias_func_skrypty_character_state_reporting_intox()
+    scripts.character.state_reporting.say_state("intox")
+end
+
+function alias_func_skrypty_character_state_reporting_fatigue()
+    scripts.character.state_reporting.say_state("fatigue")
+end
+
+function alias_func_skrypty_character_state_reporting_stuffed()
+    scripts.character.state_reporting.say_state("stuffed")
+end
+
+function alias_func_skrypty_character_state_reporting_soaked()
+    scripts.character.state_reporting.say_state("soaked")
+end
+
+function alias_func_skrypty_character_state_reporting_encumbrance()
+    scripts.character.state_reporting.say_state("encumbrance")
+end
+
+    


### PR DESCRIPTION
Niektóre statystyki postaci nie są widoczne z zewnątrz - np. poziom zmęczenia, obciązenia, głodu, 
pragnienia, upicie czy many. Aby ułatwić przekazywanie tych wartości innym graczom została dodana komenda
`/zamelduj <co>` która uruchamia prekonfigurowane komendy mające za zadanie poinformować innych o stanie twojej postaci. 

Przykładowo:

```
> /zamelduj zmeczenie
Mowisz: Troche zmeczony.
```

lub w skróconej formie:

```
> /zamzme
Mowisz: Troche zmeczony.
```

Analogiczne komendy zostały dodane dla pozostałych statystyk:

* `/zamelduj zmeczenie` lub `/zamzme`
* `/zamelduj obciazenie` lub `/zamobc`
* `/zamelduj mane` lub `/zamman`
* `/zamelduj glod` lub `/zamglo`
* `/zamelduj pragnienie` lub `/zampra`
* `/zamelduj upicie` lub `/zamupi`

Bieżąca wartość stystyki brana jest z automatycznie z GMCP. 

Komendy do wysłania ustawiane są w pliku konfiguracji postaci i mają formę listy komend. Za każdym kolejnym wywołaniem wysyłana jest kolejna komenda z tej listy. Ustawienia przyjmują osobne wartości w formie męskiej i żeńskiej, tak by domyślne  działały dla postaci obu płci (różna odmiana) oraz by łatwo można było przenosić ustawienia pomiędzy postaciami. Zawsze używana jest tylko wartość pasująca do płci otrzymanej z GMCP.

Jeżeli chcesz wysłać więcej niż jedną komendę na raz musisz podać je jako jedną wartość i oddzielić znakiem separatora komend (najczęsciej `;`)

Przykładowo dla konfiguracji:

```json
"scripts.character.state_reporting.fatigue.options_male.0": [
    "usmiechnij sie dumnie;'W pelni wypoczety.", 
    "machnij reka lekko;'W pelni sil."
],
```

użycie będzie wyglądało następująco:

```
/zamzme
Usmiechasz sie dumnie.
Mowisz: W pelni wypoczety.
/zamzme
Machasz reka lekko.
Mowisz: W pelni sil.
/zamzme                  
Usmiechasz sie dumnie.
Mowisz: W pelni wypoczety.
```

