### PR TITLE
Poprawki oznaczania ciosów jataganem.

### DIFF
--- a/Arkadia.xml
+++ b/Arkadia.xml
@@ -3977,14 +3977,14 @@
 								<colorTriggerFgColor>#000000</colorTriggerFgColor>
 								<colorTriggerBgColor>#000000</colorTriggerBgColor>
 								<regexCodeList>
-									<string>Jasniejaca luna znaczy powietrze, gdy dlugim cieciem jasniejacego zdobionego jatagana</string>
-									<string>Nagly blysk rozswietla cale otoczenie, gdy szybkim pchnieciem jasniejacego zdobionego jatagana</string>
-									<string>Swietlista smuga przecina powietrze, gdy szybkim pchnieciem jasniejacego zdobionego jatagana</string>
+									<string>^Jasniejaca luna znaczy powietrze, gdy (?:dlugim cieciem)|(?:szybkim pchnieciem) jasniejacego zdobionego jatagana</string>
+									<string>^Nagly blysk rozswietla cale otoczenie, gdy (?:dlugim cieciem)|(?:szybkim pchnieciem) jasniejacego zdobionego jatagana</string>
+									<string>^Swietlista smuga przecina powietrze, gdy (?:dlugim cieciem)|(?:szybkim pchnieciem) jasniejacego zdobionego jatagana</string>
 								</regexCodeList>
 								<regexCodePropertyList>
-									<integer>0</integer>
-									<integer>0</integer>
-									<integer>0</integer>
+									<integer>1</integer>
+									<integer>1</integer>
+									<integer>1</integer>
 								</regexCodePropertyList>
 								<Trigger isActive="yes" isFolder="no" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 									<name>ledwo-muskasz</name>


### PR DESCRIPTION
Pozostałe warianty opisu ciosu dla jasniejacego zdobionego jatagana.

```
/fake Jasniejaca luna znaczy powietrze, gdy dlugim cieciem jasniejacego zdobionego jatagana ledwo muskasz ciemnookiego
/fake Jasniejaca luna znaczy powietrze, gdy dlugim cieciem jasniejacego zdobionego jatagana lekko ranisz ciemnookiego
/fake Jasniejaca luna znaczy powietrze, gdy dlugim cieciem jasniejacego zdobionego jatagana masakrujesz czerwonookiego
/fake Jasniejaca luna znaczy powietrze, gdy dlugim cieciem jasniejacego zdobionego jatagana ranisz ciemnookiego
/fake Jasniejaca luna znaczy powietrze, gdy szybkim pchnieciem jasniejacego zdobionego jatagana ledwo muskasz ciemnookiego
/fake Jasniejaca luna znaczy powietrze, gdy szybkim pchnieciem jasniejacego zdobionego jatagana lekko ranisz ciemnookiego
/fake Jasniejaca luna znaczy powietrze, gdy szybkim pchnieciem jasniejacego zdobionego jatagana ranisz ciemnookiego postawnego
/fake Nagly blysk rozswietla cale otoczenie, gdy dlugim cieciem jasniejacego zdobionego jatagana ledwo muskasz wielkonosego
/fake Nagly blysk rozswietla cale otoczenie, gdy dlugim cieciem jasniejacego zdobionego jatagana lekko ranisz zoltookiego
/fake Nagly blysk rozswietla cale otoczenie, gdy dlugim cieciem jasniejacego zdobionego jatagana masakrujesz ciemnoskorego
/fake Nagly blysk rozswietla cale otoczenie, gdy dlugim cieciem jasniejacego zdobionego jatagana powaznie ranisz ciemnookiego
/fake Nagly blysk rozswietla cale otoczenie, gdy dlugim cieciem jasniejacego zdobionego jatagana ranisz ciemnookiego zrecznego
/fake Nagly blysk rozswietla cale otoczenie, gdy szybkim pchnieciem jasniejacego zdobionego jatagana ledwo muskasz
/fake Nagly blysk rozswietla cale otoczenie, gdy szybkim pchnieciem jasniejacego zdobionego jatagana lekko ranisz
/fake Nagly blysk rozswietla cale otoczenie, gdy szybkim pchnieciem jasniejacego zdobionego jatagana masakrujesz
/fake Nagly blysk rozswietla cale otoczenie, gdy szybkim pchnieciem jasniejacego zdobionego jatagana ranisz
/fake Swietlista smuga przecina powietrze, gdy dlugim cieciem jasniejacego zdobionego jatagana bardzo ciezko ranisz
/fake Swietlista smuga przecina powietrze, gdy dlugim cieciem jasniejacego zdobionego jatagana ledwo muskasz ciemnookiego
/fake Swietlista smuga przecina powietrze, gdy dlugim cieciem jasniejacego zdobionego jatagana lekko ranisz zoltookiego
/fake Swietlista smuga przecina powietrze, gdy dlugim cieciem jasniejacego zdobionego jatagana masakrujesz wielkonosego
/fake Swietlista smuga przecina powietrze, gdy dlugim cieciem jasniejacego zdobionego jatagana ranisz zoltookiego muskularnego
/fake Swietlista smuga przecina powietrze, gdy szybkim pchnieciem jasniejacego zdobionego jatagana ledwo muskasz
/fake Swietlista smuga przecina powietrze, gdy szybkim pchnieciem jasniejacego zdobionego jatagana lekko ranisz
/fake Swietlista smuga przecina powietrze, gdy szybkim pchnieciem jasniejacego zdobionego jatagana powaznie ranisz
/fake Swietlista smuga przecina powietrze, gdy szybkim pchnieciem jasniejacego zdobionego jatagana ranisz wielkonosego
```