### PR TITLE
Poprawki oznaczania parowania.

### DIFF
--- a/Arkadia.xml
+++ b/Arkadia.xml
@@ -3010,7 +3010,7 @@
 									<string>^[ &gt;]*Pazury .* zeslizguja sie po .*\.$</string>
 									<string>^[ &gt;]*[a-zA-Z (),!]+ lecz uderzenie zatrzymuje sie na (twym|twych|twej) [a-z ]+\.$</string>
 									<string>^[ &gt;]*[a-zA-Z (),!]+ gdy jego uderzenie zeslizguje sie po (twym|twych|twej) [a-z ]+\.$</string>
-									<string>^[ &gt;]*[a-zA-Z (),!]+ by wyprowadzic cios zdolnyprzebic (twoj|twoja|twe) [a-z ]+\.$</string>
+									<string>^[ &gt;]*[a-zA-Z (),!]+ by wyprowadzic cios zdolny przebic (twoj|twoja|twe) [a-z ]+\.$</string>
 								</regexCodeList>
 								<regexCodePropertyList>
 									<integer>1</integer>
@@ -12212,7 +12212,7 @@
 								<colorTriggerBgColor>#000000</colorTriggerBgColor>
 								<regexCodeList>
 									<string>(^[ &gt;]*Wykonujesz zamaszyste ciecie [a-z ]+ mierzac w [a-zA-Z (),!]+, lecz [a-z]+ zbija .* linii ataku .*\.$)</string>
-									<string>(^[ &gt;]*Nagle .* wykonuje zamaszysty cios .* celujac w .*, lecz [a-z]+ sprawnie paruje go .*\.$)</string>
+									<string>(^[ &gt;]*Nagle .* wykonuje zamaszysty cios .* celujac w .*, lecz [a-z]+ (sprawnie |)paruje go .*\.$)</string>
 									<string>(^[ &gt;]*.* wykonuje zamaszyste ciecie .* mierzac w .*, lecz [a-z]+ zbija je z linii ataku .*\.)</string>
 									<string>(^[ &gt;]*Wyprowadzasz szybkie pchniecie .* w .*, lecz [a-z]+ zbija je z linii ataku .*\.$)</string>
 									<string>(^[ &gt;]*.* wykonuje zamaszyste ciecie .* mierzac w .*, lecz .* oslania sie .*\.$)</string>
@@ -12260,8 +12260,12 @@
 								<colorTriggerBgColor>#000000</colorTriggerBgColor>
 								<regexCodeList>
 									<string>^[ &gt;]*.* trafia ([a-z]+).* w .*, lecz caly impet uderzenia zostaje .*</string>
+									<string>^[ &gt;]*[a-zA-Z (),!]+ lecz uderzenie zatrzymuje sie na (jego|jej) [a-z ]+\.$</string>
+									<string>^[ &gt;]*[a-zA-Z (),!]+ (gdy jego uderzenie|lecz) zeslizguje sie po (jego|jej) [a-z ]+\.$</string>
 								</regexCodeList>
 								<regexCodePropertyList>
+									<integer>1</integer>
+									<integer>1</integer>
 									<integer>1</integer>
 								</regexCodePropertyList>
 							</Trigger>


### PR DESCRIPTION
Test:
```
/fake Nagle wyszkolony jednooki mezczyzna wykonuje zamaszysty cios waskim krotkim jataganem celujac w XXX, lecz ten paruje go adamantytowym mlotem bojowym.
/fake Nagle grozny potezny mezczyzna wykonuje zamaszysty cios guzowata sekata pala celujac w XXX, lecz uderzenie zatrzymuje sie na jego pelnej bialej zbroi rycerskiej z herbem.
/fake Nagle grozny potezny mezczyzna wykonuje zamaszysty cios guzowata sekata pala celujac w XXX, lecz uderzenie zatrzymuje sie na jej bialoblekitnej smoczej zbroi.
/fake Cios dosiega dlugowlosym urodziwym mezczyzna, lecz zeslizguje sie po jego stalowej mocnej przylbicy.
```