### PR TITLE
List poprawki

### DIFF
--- a/Arkadia.xml
+++ b/Arkadia.xml
@@ -25734,6 +25734,13 @@
 					<packageName></packageName>
 					<regex>^/list$</regex>
 				</Alias>
+				<Alias isActive="yes" isFolder="no">
+					<name>Szybki list</name>
+					<script>alias_func_list_fast()</script>
+					<command></command>
+					<packageName></packageName>
+					<regex>^/list (\w+) (.*)$</regex>
+				</Alias>
 			</AliasGroup>
 			<Alias isActive="yes" isFolder="no">
 				<name>/konfiguracja</name>

--- a/skrypty/mail/mail_creator.lua
+++ b/skrypty/mail/mail_creator.lua
@@ -69,6 +69,7 @@ end
 function scripts.mail_creator:start()
     openUserWindow(self.window_name, false, false)
     setFont(self.window_name, getFont())
+    setFontSize(self.window_name, getFontSize())
     setUserWindowTitle(self.window_name, "Tworzenie wiadomosci")
 
     local x = 1
@@ -80,18 +81,8 @@ function scripts.mail_creator:start()
 
     moveWindow(self.window_name, 10,30)
 
-    createMiniConsole(self.window_name, self.to, 10, 10, x, 20)
-    clearUserWindow(self.to)
-    echo(self.to, "Do: ")
-
-    createMiniConsole(self.window_name, self.subject, 10, 30, x, 20)
-    clearUserWindow(self.subject)
-
-    createMiniConsole(self.window_name, self.cc, 10, 50, x, 20)
-    clearUserWindow(self.cc)
-    
-    createMiniConsole(self.window_name, self.body, 10, 80, x, 500)
-    clearUserWindow(self.body)
+    clearUserWindow(self.window_name)
+    echo(self.window_name, "Do: ")
 
     enableCommandLine(self.window_name)
     setCmdLineAction(self.window_name, "mailCreatorAddLine")
@@ -133,9 +124,8 @@ function mailCreatorAddLine(line)
             return
         end
         self.mail.to = line
-        clearUserWindow(self.to)
-        echo(self.to, "Do: " .. self.mail.to)
-        echo(self.subject, "Temat: ")
+        echo(self.window_name, self.mail.to)
+        echo(self.window_name, "\nTemat: ")
         return
     end
 
@@ -146,17 +136,16 @@ function mailCreatorAddLine(line)
             return
         end
         self.mail.subject = line
-        clearUserWindow(self.subject)
-        echo(self.subject, "Temat: " .. self.mail.subject)
-        echo(self.cc, "CC: ")
+        echo(self.window_name, self.mail.subject)
+        echo(self.window_name, "\nCC: ")
         return
     end
 
     if not self.mail.cc then
         self.mail.cc = line
         clearUserWindow(self.cc)
-        echo(self.cc, "CC: " .. (self.mail.cc:trim() == "" and "--" or self.mail.cc))
-        cecho(self.body, "<light_slate_gray>Wpisz tresc wiadomosci...<reset>")
+        echo(self.window_name, (self.mail.cc:trim() == "" and "--" or self.mail.cc))
+        cecho(self.window_name, "\n<light_slate_gray>Wpisz tresc wiadomosci...<reset>")
         return
     end
 
@@ -177,9 +166,12 @@ function scripts.mail_creator:append_input(line)
 end
 
 function scripts.mail_creator:print()
-    clearUserWindow(self.body)
+    clearUserWindow(self.window_name)
+    echo(self.window_name, "Do: " .. self.mail.to .. "\n")
+    echo(self.window_name, "Temat: " .. self.mail.subject .. "\n")
+    echo(self.window_name, "CC: " .. (self.mail.cc:trim() == "" and "--" or self.mail.cc) .. "\n")
     for _, line in pairs(self:crate_content()) do
-        echo(self.body, line .. "\n")
+        echo(self.window_name, line .. "\n")
     end
 end
 

--- a/skrypty/mail/mail_creator.lua
+++ b/skrypty/mail/mail_creator.lua
@@ -66,7 +66,7 @@ local function justify(line, limit)
     return table.concat(words)
 end
 
-function scripts.mail_creator:start()
+function scripts.mail_creator:window()
     openUserWindow(self.window_name, false, false)
     setFont(self.window_name, getFont())
     setFontSize(self.window_name, getFontSize())
@@ -82,7 +82,6 @@ function scripts.mail_creator:start()
     moveWindow(self.window_name, 10,30)
 
     clearUserWindow(self.window_name)
-    echo(self.window_name, "Do: ")
 
     enableCommandLine(self.window_name)
     setCmdLineAction(self.window_name, "mailCreatorAddLine")
@@ -94,13 +93,17 @@ function scripts.mail_creator:start()
             border: 1px solid #333;
         }
     ]])
+end
 
+function scripts.mail_creator:start()
     self.mail = {
         to = nil,
         subject = nil,
         cc = nil,
         content = {}
     }
+    self:window()
+    echo(self.window_name, "Do: ")
 end
 
 function mailCreatorAddLine(line)
@@ -114,6 +117,12 @@ function mailCreatorAddLine(line)
 
     if line:trim() == "~q" then
         hideWindow(self.window_name)
+        return
+    end
+
+    if line:trim() == "~d" then
+        table.remove(self.mail.content, table.size(self.mail.content))
+        self:print()
         return
     end
 
@@ -143,7 +152,6 @@ function mailCreatorAddLine(line)
 
     if not self.mail.cc then
         self.mail.cc = line
-        clearUserWindow(self.cc)
         echo(self.window_name, (self.mail.cc:trim() == "" and "--" or self.mail.cc))
         cecho(self.window_name, "\n<light_slate_gray>Wpisz tresc wiadomosci...<reset>")
         return
@@ -194,6 +202,25 @@ function scripts.mail_creator:send()
         send("**")
     end, 1)
     tempTimer(10, function() killTrigger(trigger) end)
+end
+
+function scripts.mail_creator:fast_mail(to, subject)
+    self.mail = {
+        to = to,
+        subject = subject,
+        cc = "",
+        content = {}
+    }
+
+    self:window()
+    echo(self.window_name, "Do: " .. self.mail.to .. "\n")
+    echo(self.window_name, "Temat: " .. self.mail.subject .. "\n")
+    echo(self.window_name, "CC: --\n")
+    cecho(self.window_name, "<light_slate_gray>Wpisz tresc wiadomosci...<reset>")
+end
+
+function alias_func_list_fast()
+    scripts.mail_creator:fast_mail(matches[2], matches[3])
 end
 
 function alias_func_list()


### PR DESCRIPTION
Nie wyswietlalo lini: Do, Temat i CC dla rozmiaru czcionki wiekszej od 10 (w win10 domyslnie ustawialo 12).
Ustawianie rozmiaru czcionki takiej jak glowne okno.
Opcja edycji ~d usuwa ostatnio dodana linie wiadomosci.
/list [adresat] [temat] otworzy okno z wypelnionymi headerami (przyklad zastosowania - alias msg = /list obecni Koperta)
