### PR TITLE
Komenda /beep do przetestowania beepa

### DIFF
--- a/Arkadia.xml
+++ b/Arkadia.xml
@@ -27583,6 +27583,13 @@
 						<packageName></packageName>
 						<regex>^/abeep ([012])$</regex>
 					</Alias>
+					<Alias isActive="yes" isFolder="no">
+						<name>test</name>
+						<script>alias_func_skrypty_misc_attack_beep_test()</script>
+						<command></command>
+						<packageName></packageName>
+						<regex>^/beep$</regex>
+					</Alias>
 				</AliasGroup>
 				<Alias isActive="yes" isFolder="no">
 					<name>exp_start</name>

--- a/skrypty/misc/attack_beep.lua
+++ b/skrypty/misc/attack_beep.lua
@@ -57,7 +57,16 @@ function misc.attack_beep:process_player_attack(name, upper)
     resetFormat()
 end
 
+function misc.attack_beep:test_beep()
+    raiseEvent("playBeep")
+    scripts:print_log("Beepuje")
+end
+
 function alias_func_skrypty_misc_attack_beep_set_level()
     misc.attack_beep:set_attack_level(tonumber(matches[2]))
 end
 
+
+function alias_func_skrypty_misc_attack_beep_test()
+    misc.attack_beep:test_beep()
+end


### PR DESCRIPTION
Po to by dało się przetestować czy słychać beepa nie czekając aż Zetu cię zaatakuje na idlu.