### PR TITLE
Poprawki na ptakopodobnego.

### DIFF
--- a/Arkadia.xml
+++ b/Arkadia.xml
@@ -25628,6 +25628,7 @@ display("NI")</script>
 						<string>^[ &gt;]*(Nie mozesz sie tam udac, gdyz |)([Op]*pierzona skrzydlata bestia|[Ss]krzydlaty lwiopodobny potwor|[a-z]+ niebezpieczny gryf) swoim cielskiem zagradza ci droge( ucieczki|) na .*</string>
 						<string>^[ &gt;]*Nie mozesz sie tam udac, gdyz siedzisz.*</string>
 						<string>^[ &gt;]*Nie mozesz sie tam udac, gdyz .* blokuj(e|a) ci droge na.*</string>
+						<string>^[ &gt;]*Nie mozesz sie tam udac, gdyz pod wplywem spojrzenia zoltych slepi zlowrogiego ptakopodobnego mezczyzny.*</string>
 						<string>^[ &gt;]*Nie mozesz wyjsc z domu poniewaz stoisz na krzesle\.$</string>
 						<string>^[ &gt;]*Nie mozesz wyjsc z domu poniewaz stoisz na szafie\.$</string>
 						<string>^[ &gt;]*Nie mozesz zejsc gdyz klapa jest zamknieta\.$</string>

--- a/skrypty/ui/misc/ptakopodobny.lua
+++ b/skrypty/ui/misc/ptakopodobny.lua
@@ -1,3 +1,3 @@
 function trigger_func_skrypty_ui_misc_ptakopodobny_inkantuje()
-    scripts.messages:show("KAPŁAN CZARUJE - UCIEKAJ!!!", "IndianRed")
+    cecho("\n\n\n<tomato>[    CZAR    ] Kapłan czaruje\n\n\n")
 end


### PR DESCRIPTION
1. Wywalam informacje "uciekaj" bo po ostatnich zmianach już nie da się uciec oraz zmieniam formatowanie wiadomości na standardowe "CZAR".
2. Dodaje bloker

   ```
   Nie mozesz sie tam udac, gdyz pod wplywem spojrzenia zoltych slepi zlowrogiego ptakopodobnego mezczyzny twe cialo 
   zamiera w bezruchu, zas w glowie jest jedynie pustka.
    ```
