### PR TITLE
Komendy dot. pojemnikow powinny dzialac tylko na pojemnikach ktore postac ma przy sobie

### DIFF
--- a/skrypty/inventory/bags.lua
+++ b/skrypty/inventory/bags.lua
@@ -17,25 +17,25 @@ scripts.inv["bag_name"] = {
 }
 
 scripts.inv["bag_in_dopelniacz"] = {
-    ["plecak"] = "plecaka",
-    ["torba"] = "torby",
-    ["worek"] = "worka",
-    ["sakiewka"] = "sakiewki",
-    ["mieszek"] = "mieszka",
-    ["sakwa"] = "sakwy",
-    ["wor"] = "wora",
-    ["szkatulka"] = "szkatulki",
+    ["plecak"] = "swojego plecaka",
+    ["torba"] = "swojej torby",
+    ["worek"] = "swojego worka",
+    ["sakiewka"] = "swojej sakiewki",
+    ["mieszek"] = "swojego mieszka",
+    ["sakwa"] = "swojej sakwy",
+    ["wor"] = "swojego wora",
+    ["szkatulka"] = "swojej szkatulki",
 }
 
 scripts.inv["bag_in_biernik"] = {
-    ["plecak"] = "plecak",
-    ["torba"] = "torbe",
-    ["worek"] = "worek",
-    ["sakiewka"] = "sakiewke",
-    ["mieszek"] = "mieszek",
-    ["sakwa"] = "sakwe",
-    ["wor"] = "wor",
-    ["szkatulka"] = "szkatulke",
+    ["plecak"] = "swoj plecak",
+    ["torba"] = "swoja torbe",
+    ["worek"] = "swoj worek",
+    ["sakiewka"] = "swoja sakiewke",
+    ["mieszek"] = "swoj mieszek",
+    ["sakwa"] = "swoja sakwe",
+    ["wor"] = "swoj wor",
+    ["szkatulka"] = "swoja szkatulke",
 }
 
 scripts.inv["money_bag_1"] = "plecak"


### PR DESCRIPTION
Ostatnio różni dziwni ludzie rozkładają plecaki/sakiewki w bankach i na statkach żeby eksploitować sytuacje gdzie denominując pieniądze lub kupując bilet na statek odkładasz pieniądze do leżącego plecaka zamiast do swojego. 

Proponuje wymusić by komendy w skryptach działały tylko na pojemnikach które postać ma przy sobie. 

```
wem
wez monety z swojej sakiewki
Bierzesz dziewietnascie srebrnych monet, mithrylowa monete, wiele zlotych monet i piec miedzianych monet z otwartej
porzadnej czarnej sakiewki z runami.

wlm
wloz monety do swojej sakiewki
Wkladasz piec miedzianych monet, wiele zlotych monet, mithrylowa monete i 24 srebrne monety do otwartej porzadnej
czarnej sakiewki z runami.
```
