### PR TITLE
Nie odpala sie bloker w tunelu

### DIFF
--- a/Arkadia.xml
+++ b/Arkadia.xml
@@ -25716,6 +25716,7 @@
 						<integer>1</integer>
 						<integer>1</integer>
 						<integer>1</integer>
+						<integer>1</integer>
 						<integer>0</integer>
 						<integer>0</integer>
 					</regexCodePropertyList>


### PR DESCRIPTION
Nie odpala `^[ &gt;]*Niestety, wyglada na to, ze wiecej osob niz jedna sie tam nie zmiesci\.$` jako regex.