### PR TITLE
Poprawki na zapraszanie/opuszczanie drużyny przez nieprzedstawione postacie

### DIFF
--- a/Arkadia.xml
+++ b/Arkadia.xml
@@ -46,12 +46,12 @@
 					<colorTriggerFgColor>#000000</colorTriggerFgColor>
 					<colorTriggerBgColor>#000000</colorTriggerBgColor>
 					<regexCodeList>
-						<string>.*rozwiazuje druzyne\.$</string>
-						<string>^.*Porzucasz swoja druzyne\.$</string>
-						<string>.*zmusza cie do opuszczenia druzyny\.$</string>
-						<string>Porzucasz druzyne, ktorej przewodzil.s</string>
-						<string>Zmuszasz \[?([a-zA-Z ]+)\]? do opuszczenia druzyny\.$</string>
-						<string>^\[?([a-zA-Z ]+)\]? porzuca twoja druzyne\.$</string>
+						<string>^\[?([A-Z][a-z ]+?)\]? rozwiazuje druzyne\.$</string>
+						<string>^Porzucasz swoja druzyne\.$</string>
+						<string>^\[?([A-Z][a-z ]+?)\]? zmusza cie do opuszczenia druzyny\.$</string>
+						<string>^Porzucasz druzyne, ktorej przewodzil[ea]s\.$</string>
+						<string>^Zmuszasz \[?([A-Za-z][a-z ]+?)\]? do opuszczenia druzyny\.$</string>
+						<string>^\[?([A-Z][a-z ]+?)\]? porzuca twoja druzyne\.$</string>
 					</regexCodeList>
 					<regexCodePropertyList>
 						<integer>1</integer>
@@ -100,7 +100,7 @@
 					<colorTriggerFgColor>#000000</colorTriggerFgColor>
 					<colorTriggerBgColor>#000000</colorTriggerBgColor>
 					<regexCodeList>
-						<string>^[ &gt;]?\[?(\w*)\]? zaprasza cie do swojej druzyny\.$</string>
+						<string>\[?([A-Z][a-z ]+?)\]? zaprasza cie do swojej druzyny\.$</string>
 					</regexCodeList>
 					<regexCodePropertyList>
 						<integer>1</integer>
@@ -147,6 +147,7 @@
 					</regexCodePropertyList>
 				</Trigger>
 			</TriggerGroup>
+
 			<TriggerGroup isActive="yes" isFolder="yes" isTempTrigger="no" isMultiline="no" isPerlSlashGOption="no" isColorizerTrigger="no" isFilterTrigger="no" isSoundTrigger="no" isColorTrigger="no" isColorTriggerFg="no" isColorTriggerBg="no">
 				<name>inventory</name>
 				<script></script>


### PR DESCRIPTION
Nie łapało jak nieprzedstawiona osoba zaprasza do drużyny.
Nie łapało jak nieprzedstawiona osoba porzuca drużynę lub jest zmuszona do jej opuszczenia.

Test:

```
/fake Rono zaprasza cie do swojej druzyny.
/fake [Rono] zaprasza cie do swojej druzyny.
/fake Barczysty czarnooki mezczyzna zaprasza cie do swojej druzyny.

/fake Rono rozwiazuje druzyne.
/fake [Rono] rozwiazuje druzyne.
/fake Barczysty czarnooki mezczyzna rozwiazuje druzyne.

/fake Rono porzuca twoja druzyne.
/fake [Rono] porzuca twoja druzyne.
/fake Barczysty czarnooki mezczyzna porzuca twoja druzyne.

/fake Zmuszasz Rono do opuszczenia druzyny.
/fake Zmuszasz [Rono] do opuszczenia druzyny.
/fake Zmuszasz barczystego czarnookiego mezczyzne do opuszczenia druzyny.
```