### PR TITLE
bind allows the user to break objs[avatar].paralysis, with cfg

### DIFF
--- a/config.md
+++ b/config.md
@@ -164,6 +164,11 @@ Wartości:
 
 ---
 
+## `scripts.character.bind_paralysis_breaker`
+
+Bindowanie komendy "przerwij" po rozpoczeciu czynnosci, ktora paralizuje ruch, np tropienie, wspinaczka.
+
+---
 ## `scripts.character.combat_state.trigger_blocked_actions_bind`
 
 Bindowanie nieudanej akcji ze wzgledu na niedawne zakonczenie walki.

--- a/config_schema.json
+++ b/config_schema.json
@@ -338,6 +338,12 @@
       "macros_on_modify": []
     },
     {
+      "name": "scripts.character.bind_paralysis_breaker",
+      "default_value": false,
+      "field_type": "boolean",
+      "macros_on_modify": []
+    },
+    {
       "name": "scripts.character.combat_state.trigger_blocked_actions_bind",
       "default_value": true,
       "field_type": "boolean",

--- a/mapper/pausers.lua
+++ b/mapper/pausers.lua
@@ -29,6 +29,9 @@ function amap.pausers:on()
     disableKey("temp_bind-")
     disableKey("temp_bind=")
     raiseEvent("amapPauserStarted")
+    if scripts.character.bind_paralysis_breaker == true then
+        scripts.utils.bind_functional("przestan", silent)
+    end
 end
 
 function amap.pausers:off()


### PR DESCRIPTION
![Screenshot from 2022-01-28 18-35-48](https://user-images.githubusercontent.com/11772152/151606425-88ba40be-d483-4124-abf7-7046803fb17f.png)
