### PR TITLE
Obsługa pory dnia i pory roku w footerze przez gmcp.

### DIFF
--- a/config.md
+++ b/config.md
@@ -1080,7 +1080,8 @@ Mozliwe opcje to:
 * `combat`         - stan walki + ochloniecia po walce
 * `package`        - aktualnie pobrana paczka pocztowa
 * `placeholder`    - puste miejsce, mozna dac odstep pomiedzy konkretnymi elementami, element moze byc deklarowany pare razy
-
+* `daylight`       - pora dnia (dzień/noc)
+* `season`         - pora roku
 ### Przykład
 ```json
 "scripts.ui.cfg.info_items" : ["weapon", "order", "cover", "killed", "sneaky", "hidden", "attack", "collect","mail", "alert", "lamp", "compass", "combat" ]

--- a/scriptsList.lua
+++ b/scriptsList.lua
@@ -267,6 +267,7 @@ return {
     "skrypty/ui/talk_window/ui_talk_window",
     "skrypty/ui/talk_window/talk_history",
     "skrypty/ui/gmcp_handlers/gmcp_state_handler",
+    "skrypty/ui/gmcp_handlers/gmcp_room_time_handler",
     "skrypty/ui/gmcp_handlers/weapon_state",
     "skrypty/ui/gmcp_handlers/guard_state",
     "skrypty/ui/gmcp_handlers/order_state",

--- a/skrypty/ui/footer_info/info_updates.lua
+++ b/skrypty/ui/footer_info/info_updates.lua
@@ -283,3 +283,50 @@ end
 function scripts_ui_info_release_guards_click()
     ateam:switch_releasing_guards()
 end
+
+--
+-- daylight
+--
+function scripts_ui_info_daylight_click()
+    send("czas")
+end
+
+function scripts.ui:info_daylight_update(val)
+    if not scripts.ui.footer_info_daylight then
+        return
+    end
+    if val == true then
+        scripts.ui.footer_info_daylight:updateValue("Dzien")
+    elseif val == false then
+        scripts.ui.footer_info_daylight:updateValue("Noc")
+    else
+        scripts.ui.footer_info_daylight:updateValue("")
+    end
+end
+
+--
+-- season
+--
+function scripts_ui_info_season_click()
+    send("czas")
+end
+
+scripts.ui.info_season_names = scripts.ui.info_season_names or {
+    [0] = "Wiosna",
+    [1] = "Lato",
+    [2] = "Jesien",
+    [3] = "Zima"
+}
+
+function scripts.ui:info_season_update(val)
+    if not scripts.ui.footer_info_season then
+        return
+    end
+
+    if scripts.ui.info_season_names[val] then
+        local label = scripts.ui.info_season_names[val]
+        scripts.ui.footer_info_season:updateValue(label)
+    else
+        scripts.ui.footer_info_season:updateValue("")
+    end
+end

--- a/skrypty/ui/footer_info/ui_footer_info.lua
+++ b/skrypty/ui/footer_info/ui_footer_info.lua
@@ -31,7 +31,9 @@ function scripts.ui:setup_footer_info()
         ["lamp"] = self.setup_footer_info_lamp,
         ["compass"] = self.setup_footer_info_compass,
         ["combat"] = self.setup_footer_info_combat_state,
-        ["placeholder"] = self.setup_placeholder
+        ["placeholder"] = self.setup_placeholder,
+        ["daylight"] = self.setup_footer_info_daylight,
+        ["season"] = self.setup_footer_info_season
     }
 
     raiseEvent("footerInfoCreators", self.footer_info_elements_creators)
@@ -243,5 +245,37 @@ function scripts.ui:setup_placeholder()
     })
     self.info_placeholders[id]:setStyleSheet(self.footer_info_core_base_css:getCSS())
     self:add_footer_element(self.info_placeholders[id])
+end
+
+
+function scripts.ui:setup_footer_info_daylight()
+    self.footer_info_daylight = Geyser.Label:new({
+        name = "scripts.ui.footer_info_daylight",
+        fontSize = self.footer_font_size,
+    })
+    self.footer_info_daylight:setStyleSheet(self.footer_info_core_base_css:getCSS())
+    self.footer_info_daylight:setClickCallback("scripts_ui_info_daylight_click")
+    function self.footer_info_daylight:updateValue(val)
+        scripts.ui.footer_info_daylight:echo("<font color='" .. scripts.ui["footer_info_normal"] .. "'>Pora dnia:</font> <font color='" .. scripts.ui["footer_info_green"] .. "'>"..val.."</font>")
+    end
+    self.footer_info_daylight:updateValue('')
+    self:add_footer_element(self.footer_info_daylight)
+    setLabelCursor(self.footer_info_daylight.name, "PointingHand")
+end
+
+function scripts.ui:setup_footer_info_season()
+    self.footer_info_season = Geyser.Label:new({
+        name = "scripts.ui.footer_info_season",
+        fontSize = self.footer_font_size,
+    })
+    self.footer_info_season:setStyleSheet(self.footer_info_core_base_css:getCSS())
+    self.footer_info_season:setClickCallback("scripts_ui_info_season_click")
+    function self.footer_info_season:updateValue(val)
+        scripts.ui.footer_info_season:echo("<font color='" .. scripts.ui["footer_info_normal"] .. "'>Pora roku:</font> <font color='" .. scripts.ui["footer_info_green"] .. "'>"..val.."</font>")
+    end
+    self.footer_info_season:updateValue('')
+
+    self:add_footer_element(self.footer_info_season)
+    setLabelCursor(self.footer_info_season.name, "PointingHand")
 end
 

--- a/skrypty/ui/gmcp_handlers/gmcp_room_time_handler.lua
+++ b/skrypty/ui/gmcp_handlers/gmcp_room_time_handler.lua
@@ -1,0 +1,21 @@
+
+scripts.ui.gmcp_room_time_handler = scripts.ui.gmcp_room_time_handler or {}
+
+function scripts.ui.gmcp_room_time_handler:update_ui()
+    if not gmcp.room or not gmcp.room.time then
+        return
+    end 
+    scripts.ui:info_daylight_update(gmcp.room.time.daylight)
+    scripts.ui:info_season_update(gmcp.room.time.season)
+end
+
+function scripts.ui.gmcp_room_time_handler:init()
+	self.ui_ready_handler = scripts.event_register:register_singleton_event_handler(self.ui_ready_handler, "uiReady", function () self:update_ui() end)
+    if scripts.event_handlers["skrypty/ui/gmcp_handlers/gmcp_room_time_handler.gmcp.room.time.gmcp_room_time_handler"] then
+        killAnonymousEventHandler(scripts.event_handlers["skrypty/ui/gmcp_handlers/gmcp_room_time_handler.gmcp.room.time.gmcp_room_time_handler"])
+    end
+    
+    scripts.event_handlers["skrypty/ui/gmcp_handlers/gmcp_room_time_handler.gmcp.room.time.gmcp_room_time_handler"] = registerAnonymousEventHandler("gmcp.room.time", function () self:update_ui() end)
+end
+
+scripts.ui.gmcp_room_time_handler:init()

--- a/skrypty/ui/gmcp_handlers/gmcp_state_handler.lua
+++ b/skrypty/ui/gmcp_handlers/gmcp_state_handler.lua
@@ -7,4 +7,3 @@ if scripts.event_handlers["skrypty/ui/gmcp_handlers/gmcp_state_handler.gmcp.char
 end
 
 scripts.event_handlers["skrypty/ui/gmcp_handlers/gmcp_state_handler.gmcp.char.state.gmcp_state_handler"] = registerAnonymousEventHandler("gmcp.char.state", gmcp_state_handler)
-


### PR DESCRIPTION
Dane pobierane z ``gmcp.room.time``. Klucze konfiguracyjne footera:

``daylight`` - pora dnia (dzień/noc)
``season`` - pora roku

![image](https://user-images.githubusercontent.com/1384600/157499827-66487264-c581-4dbe-9dd4-437aaf937aa2.png)

