### PR TITLE
regmatch gdy nie github

### DIFF
--- a/skrypty/utils/installer/plugins.lua
+++ b/skrypty/utils/installer/plugins.lua
@@ -20,7 +20,7 @@ function scripts.plugins_installer:install_from_url(url)
         file_name = repo .. "." .. format
         extension = "." .. format
     else
-        file_name = url:match("([^/]+)$")
+        file_name = url:match("([^/]+)%?") or url:match("([^/]+)$")
     end
 
     plugin_name, extension = file_name:gmatch("(.+)%.(.+)$")()

--- a/skrypty/utils/installer/plugins.lua
+++ b/skrypty/utils/installer/plugins.lua
@@ -20,7 +20,7 @@ function scripts.plugins_installer:install_from_url(url)
         file_name = repo .. "." .. format
         extension = "." .. format
     else
-        file_name = url:match("/([^/]+)(?.*)$")
+        file_name = url:match("([^/]+)$")
     end
 
     plugin_name, extension = file_name:gmatch("(.+)%.(.+)$")()


### PR DESCRIPTION
U mnie ten regexp Twój jakoś nie działa ani dla pluginu hostowanego na gitlabie, ani dla lokalnych ścieżek.

```lua url="https://gitlab.com/api/v4/projects/12345/packages/generic/plugin/v2.1.17/plugin_nazwa.zip"
lua display(url)
"https://gitlab.com/api/v4/projects/12345/packages/generic/plugin/v2.1.17/plugin_nazwa.zip"
lua file_name=url:match("/([^/]+)(?.*)$")
lua display(file_name)
nil
...
lua file_name = url:match("([^/]+)$")
lua display(file_name)
"plugin_nazwa.zip"
lua  plugin_name, extension = file_name:gmatch("(.+)%.(.+)$")()
lua display(plugin_name)
"plugin_nazwa"
lua display(extension)
"zip"
```
