### PR TITLE
- Add check for empty herbs database in `smart_apply` function.

### DIFF
--- a/Arkadia.xml
+++ b/Arkadia.xml
@@ -18534,7 +18534,7 @@ scripts.misc.knowledge:stop_reading_library()</script>
 						<colorTriggerFgColor>#000000</colorTriggerFgColor>
 						<colorTriggerBgColor>#000000</colorTriggerBgColor>
 						<regexCodeList>
-							<string>^(?:[A-Z][a-z]+) (?:[a-z]+ ){1,3}rozpada(?:ja)? sie!$</string>
+							<string>^(?:[A-Z][a-z]+) (?:[a-z]+ ){1,3}(?:z umbem)? rozpada(?:ja)? sie!$</string>
 							<string>^(?:[A-Z][a-z]+) (?:[a-z-]+ ?){1,3} ((?:[A-Z][a-z]+ |(?:\w+ ){3,4}))rozpada(?:ja)? sie!</string>
 						</regexCodeList>
 						<regexCodePropertyList>
@@ -18778,7 +18778,7 @@ scripts.misc.knowledge:stop_reading_library()</script>
 						<colorTriggerFgColor>#000000</colorTriggerFgColor>
 						<colorTriggerBgColor>#000000</colorTriggerBgColor>
 						<regexCodeList>
-							<string>^[ &gt;]*(.*) wskazuje na dol\.$</string>
+							<string>^[ &gt;]*\[?(.*)\]? wskazuje na dol\.$</string>
 						</regexCodeList>
 						<regexCodePropertyList>
 							<integer>1</integer>

--- a/skrypty/herbs/smart_application.lua
+++ b/skrypty/herbs/smart_application.lua
@@ -177,6 +177,10 @@ function herbs:smart_application_init_htype_queue(htype)
 end
 
 function alias_func_skrypty_herbs_smart_apply(htype)
+    if not herbs.db or table.size(herbs.db) == 0 then
+            herbs:print_build_herbs_db_message()
+            return
+    end
     herbs:smart_application_execute(htype)
 end
 

--- a/skrypty/packages/assistant.lua
+++ b/skrypty/packages/assistant.lua
@@ -54,7 +54,7 @@ function scripts.packages:add(index, name, city, time)
     selectString(name, 1)
     local command = "wybierz paczke " .. index
     setLink(function() send(command) end, command)
-    
+
     self.current_offer[index] = { name = name, location = location }
     if city and city ~= "" then
         self.current_offer[index].city = city
@@ -171,6 +171,10 @@ function scripts.packages:get_from_db(name)
     if result and table.size(result) >= 1 then
         return result[1], table.size(result) > 0 and table.size(result) > 1
     end
+end
+
+function scripts.packages:remove_all_by_name(name)
+    db:delete(self.db.packages, "name = \"" .. name .. "\" COLLATE NOCASE")
 end
 
 function trigger_packages_assistant_open()


### PR DESCRIPTION
- Update triggers regex: include optional 'z umbem' in item decomposition and brackets around direction pointer.
- Minor whitespace cleanup in `assistant.lua`.

fixes #1514
fixes #1640
fixes #1522