### PR TITLE
Fix herbs init crash on fresh install

### DIFF
--- a/skrypty/herbs/smart_application.lua
+++ b/skrypty/herbs/smart_application.lua
@@ -9,11 +9,20 @@ function herbs:init_smart_application()
         function() herbs:reset_smart_application_queue() end)
 
     herbs:reset_smart_application_queue()
+    herbs:build_smart_application_action()
+end
+
+function herbs:build_smart_application_action()
     herbs['smart_application_action'] = {
         kon = {},
         man = {},
         zme = {}
     }
+
+    if not herbs.short_category_to_category or not herbs.herbs_categories then
+        -- baza ziol jeszcze niedostepna, akcje zbuduja sie po jej pobraniu
+        return
+    end
 
     for htype, _ in pairs(herbs['smart_application_action']) do
         local prop_category = herbs.short_category_to_category[htype]

--- a/skrypty/utils/data_downloader/download_all_data.lua
+++ b/skrypty/utils/data_downloader/download_all_data.lua
@@ -28,6 +28,8 @@ end
 function herbs_data_downloaded(resume_coroutine_id, decoded_data)
     herbs["data"] = decoded_data
     herbs:v2_init_herbs()
+    herbs:create_herbs_category_data()
+    herbs:build_smart_application_action()
     coroutine.resume(resume_coroutine_id)
     coroutine.resume(scripts.utils.download_all_data_coroutine_id)
 end


### PR DESCRIPTION
## Problem

On a fresh install `herbs_data` does not exist yet, so `herbs:v2_init_data()` returns early (`skrypty/herbs/core_v2.lua:5`) and never runs `create_herbs_category_data()`. `init_smart_application` then indexes the nil `herbs.short_category_to_category`:

```
arkadia/skrypty/herbs/smart_application.lua:19: attempt to index field 'short_category_to_category' (a nil value)
    at init_smart_application (smart_application.lua:19)
    at init_herbs (core.lua:6)
```

Because the error aborts `init_herbs`, `herbs.window:create()` never runs either.

A second, related bug: even once the download finished, `herbs_data_downloaded` only called `v2_init_herbs()`, so the categories and the smart-application action table stayed unbuilt for the rest of the session.

## Fix

- Split the action-table build out of `init_smart_application` into `herbs:build_smart_application_action()`, which returns early when the herb DB is not loaded yet.
- Call `create_herbs_category_data()` and `build_smart_application_action()` from `herbs_data_downloaded`, so categories and smart application work in the same session as the initial install rather than only after a restart.

Ordering is safe: `init_herbs` fires at `tempTimer(0.652)` and the downloader at `tempTimer(0.7)`, so `herbs_details` is initialized before the download callback runs, and `create_herbs_category_data` rebuilds its tables from scratch so a second call is harmless.

## Testing

No Lua interpreter or `luac` on the dev machine, so this is reviewed by reading, not runtime-tested.

https://claude.ai/code/session_01VTVP6tYc42qwhybDhm7yLS