### PR TITLE
Fix db indices for boxes and knowledge tables

### DIFF
--- a/skrypty/boxes.lua
+++ b/skrypty/boxes.lua
@@ -28,7 +28,7 @@ scripts.boxes.db = db:create("boxestwo", {
         updated = "",
         room_id = -1,
         changed = db:Timestamp("CURRENT_TIMESTAMP"),
-        _index = { "name" }
+        _index = { "character", "bank" }
     }
 })
 

--- a/skrypty/misc/knowledge/books.lua
+++ b/skrypty/misc/knowledge/books.lua
@@ -31,7 +31,7 @@ scripts.misc.knowledge.db = db:create("knowledge", {
         about = "",
         progress = 0,
         changed = db:Timestamp("CURRENT_TIMESTAMP"),
-        _index = { "character", "book", "about" },
+        _index = { "character", "library", "location_id", "about" },
         _violations = "IGNORE"
     }
 }


### PR DESCRIPTION
Corrects the `_index` definitions on two db tables so they match how the rows are actually looked up.

- `skrypty/boxes.lua` — index on `character`, `bank` instead of `name`.
- `skrypty/misc/knowledge/books.lua` — index on `character`, `library`, `location_id`, `about` instead of `character`, `book`, `about`.

Split out of a commit that had accidentally bundled this with an unrelated herbs fix and a CI workflow experiment.

https://claude.ai/code/session_01VTVP6tYc42qwhybDhm7yLS