### PR TITLE
Przebudowa gps: okno ostatnich linii, dopasowanie po fragmencie, wyrazenia regularne

### DIFF
--- a/Arkadia.xml
+++ b/Arkadia.xml
@@ -32154,6 +32154,13 @@ trigger_func_skrypty_ui_misc_ptakopodobny_inkantuje()</script>
 					<regex>/dodaj_gps_lokacje ([0-9,]+) (.*)$</regex>
 				</Alias>
 				<Alias isActive="yes" isFolder="no">
+					<name>add_gps_regex</name>
+					<script>alias_func_map_sync_add_gps_regex()</script>
+					<command></command>
+					<packageName></packageName>
+					<regex>/dodaj_gps_regex (.*)$</regex>
+				</Alias>
+				<Alias isActive="yes" isFolder="no">
 					<name>remove_gps</name>
 					<script>alias_func_map_sync_remove_gps()</script>
 					<command></command>

--- a/aliases.md
+++ b/aliases.md
@@ -1315,7 +1315,15 @@ Usuwa zapisane komendy podążania dla bieżącej lub wskazanej lokacji.
 
 ## `/dodaj_gps <opis>`
 
-Dodaje punkt GPS opisujący bieżącą lokację.
+Dodaje punkt GPS opisujący bieżącą lokację. Kolejne linie rozdziela się znakiem `#`,
+a linia zaczynająca się od `re:` jest wyrażeniem regularnym zamiast zwykłego tekstu —
+dzięki temu jeden punkt może łączyć stałą nazwę lokacji ze wzorcem na linię, która się
+zmienia. Zwykły tekst dopasowuje się w dowolnym miejscu linii.
+
+## `/dodaj_gps_regex <wzorce>`
+
+To samo co `/dodaj_gps`, ale każda linia jest wyrażeniem regularnym — bez potrzeby
+poprzedzania każdej z nich `re:`.
 
 ## `/dodaj_gps_obszar <obszar>`
 

--- a/mapper/gps.lua
+++ b/mapper/gps.lua
@@ -1,16 +1,35 @@
 amap.gps = amap.gps or {
-    trigger_ids = {},
-    room_id_to_gps_lines = {},
-    room_id_to_line_delta = {},
-    current_room_id_gps_index = {},
-    current_room_id_line_trigger_id = {},
-    room_id_to_within_room_ids = {},
     user_data_gps_key = "gps",
-    gps_str_separator = "#"
+    gps_str_separator = "#",
+    gps_regex_prefix = "re:",
+    -- Entries bucketed by the first word of their last line, so a line only ever
+    -- costs a lookup for the words it actually contains.
+    entries_by_word = {},
+    -- Entries that cannot be bucketed: their last line is a pattern, or has no words.
+    scanned_entries = {},
+    -- The last lines the game sent, oldest first, the current one last.
+    recent = {},
+    window_size = 1,
+    line_counter = 0,
+    synced_at_line = -1,
+    line_trigger_id = nil,
+    ready = false
 }
 
 local function trim5(s)
     return s:match '^%s*(.*%S)' or ''
+end
+
+-- The same separators the web client splits on, so a line breaks into the same words
+-- in both clients.
+local WORD_PATTERN = "[^ \t%.,!%?%*%(%)/%[%]]+"
+
+local function words_of(text)
+    local words = {}
+    for word in string.gmatch(string.lower(text), WORD_PATTERN) do
+        table.insert(words, word)
+    end
+    return words
 end
 
 function amap.gps:print_room_gps(room_id)
@@ -41,11 +60,14 @@ function amap.gps:print_room_gps(room_id)
             cecho(" <yellow>lokacje<grey>:  " .. table.concat(gps_room_element.within_room_ids, ", ") .. "\n")
         end
 
+        local modes = gps_room_element.gps_line_modes or {}
         for k, gps_string_line in pairs(gps_room_element.gps_string_lines) do
+            -- A pattern line reads as a broken literal otherwise.
+            local suffix = modes[k] == "regex" and " <grey>[regex]" or ""
             if k == 1 then
-                cecho(" <yellow>trigger<grey>: \"" .. gps_string_line .. "\"\n")
+                cecho(" <yellow>trigger<grey>: \"" .. gps_string_line .. "\"" .. suffix .. "\n")
             else
-                cecho("          \"" .. gps_string_line .. "\"\n")
+                cecho("          \"" .. gps_string_line .. "\"" .. suffix .. "\n")
             end
         end
 
@@ -53,22 +75,66 @@ function amap.gps:print_room_gps(room_id)
     end
 end
 
-function amap.gps:add_gps_to_room(room_id, gps_str, line_delta, area_name, within_room_ids)
+--- Split what the alias was given into lines and their modes.
+---
+--- Lines are separated by "#", and one prefixed with "re:" is a pattern rather than
+--- plain text - so a single entry can pair a literal room name with a pattern for the
+--- line that varies. `all_regex` marks every line instead, for an entry that is
+--- patterns throughout. A line that really has to start with "re:" is the one thing this
+--- cannot express; the map editor can.
+function amap.gps:parse_gps_string(gps_str, all_regex)
+    local raw_lines = string.split(gps_str, amap.gps.gps_str_separator)
+    if table.size(raw_lines) == 0 then
+        return nil, nil, "gps musi miec przynajmniej jedna linie"
+    end
+
+    local lines, modes, any_regex = {}, {}, false
+    for _, raw in ipairs(raw_lines) do
+        local text = trim5(raw)
+        local is_regex = all_regex or false
+
+        local without_prefix = string.match(text, "^" .. amap.gps.gps_regex_prefix .. "(.*)$")
+        if without_prefix then
+            text = trim5(without_prefix)
+            is_regex = true
+        end
+
+        if text == "" then
+            return nil, nil, "gps ma pusta linie"
+        end
+        if is_regex and not pcall(rex.find, "", text) then
+            return nil, nil, "to nie jest poprawne wyrazenie regularne: " .. text
+        end
+
+        table.insert(lines, text)
+        table.insert(modes, is_regex and "regex" or "literal")
+        if is_regex then
+            any_regex = true
+        end
+    end
+
+    return lines, (any_regex and modes or nil)
+end
+
+function amap.gps:add_gps_to_room(room_id, gps_str, area_name, within_room_ids, all_regex)
     if not room_id or not gps_str then
         error("wrong input in map_sync.gps:add_gps_to_room")
         return
     end
 
-    local gps_string_lines = string.split(gps_str, amap.gps.gps_str_separator)
-    if table.size(gps_string_lines) == 0 then
-        error("gps_string_lines has 0 elements")
+    local gps_string_lines, gps_line_modes, err = self:parse_gps_string(gps_str, all_regex)
+    if not gps_string_lines then
+        cecho("\n<orange> Map Sync: " .. err .. ". Nie dodalem gpsa.\n")
         return
     end
 
+    -- No room_id: an entry belongs to the room it is saved in, and both this script and
+    -- the web client sync to that room rather than to anything stored beside the lines.
+    -- No line_delta either: the lines of a sequence have to be consecutive, and no value
+    -- stored here has ever changed that.
     local gps_dictionary = {}
-    gps_dictionary.room_id = room_id
     gps_dictionary.gps_string_lines = gps_string_lines
-    gps_dictionary.line_delta = line_delta
+    gps_dictionary.gps_line_modes = gps_line_modes
     gps_dictionary.area_name = area_name
     gps_dictionary.within_room_ids = within_room_ids
 
@@ -90,6 +156,8 @@ function amap.gps:add_gps_to_room(room_id, gps_str, line_delta, area_name, withi
 
     final_msg = final_msg .. ". Pamietaj aby zapisac mape przed wrzuceniem na serwer\n"
     cecho(final_msg)
+
+    amap.gps:init_triggers()
 end
 
 function amap.gps:remove_gps(room_gps_id)
@@ -109,9 +177,6 @@ function amap.gps:remove_gps(room_gps_id)
     end
 
     local gps_room_elements = yajl.to_value(room_data_gps)
-    if room_data_gps and room_data_gps ~= "" then
-        gps_room_elements = yajl.to_value(room_data_gps)
-    end
 
     local filtered_gps_room_elements = {}
     for k, gps_room_element in pairs(gps_room_elements) do
@@ -128,92 +193,202 @@ function amap.gps:remove_gps(room_gps_id)
     local yajl_filtered_gps_room_elements = yajl.to_string(filtered_gps_room_elements)
     setRoomUserData(room_id, amap.gps.user_data_gps_key, yajl_filtered_gps_room_elements)
     cecho("\n<orange> Map Sync: ok, gps usuniety. Pamietaj o zapisie mapy przed wrzuceniem na serwer.\n")
+
+    amap.gps:init_triggers()
 end
 
-function amap.gps:init_triggers()
-    local gps_count = 0
+--- Resolve one stored entry into the form the matcher works with, or nil to drop it.
+---
+--- `gps_line_modes` runs parallel to `gps_string_lines`: the slot holding "regex" makes
+--- that line a pattern, anything else leaves it a literal. Entries are typed and pasted
+--- by hand, so a literal is trimmed - the whitespace around it was never part of what it
+--- means.
+function amap.gps:compile_entry(room_id, index, gps_room_element)
+    local raw_lines = gps_room_element.gps_string_lines
+    if not raw_lines or table.size(raw_lines) == 0 then
+        return nil
+    end
 
-    for id, name in pairs(getRooms()) do
-        local room_data_gps = getRoomUserData(id, amap.gps.user_data_gps_key)
-        if room_data_gps and room_data_gps ~= "" then
-            local gps_data = yajl.to_value(room_data_gps)
-            for k, v in pairs(gps_data) do
-                amap.gps:init_trigger(id, k, v.gps_string_lines, v.line_delta, v.area_name, v.within_room_ids)
-                gps_count = gps_count + 1
+    local modes = gps_room_element.gps_line_modes or {}
+    local lines = {}
+    for k, text in ipairs(raw_lines) do
+        if type(text) ~= "string" then
+            return nil
+        end
+        if modes[k] == "regex" then
+            -- A pattern that does not compile would otherwise raise on every line.
+            if not pcall(rex.find, "", text) then
+                return nil
+            end
+            table.insert(lines, { pattern = text })
+        else
+            local literal = trim5(text)
+            if literal == "" then
+                return nil
+            end
+            table.insert(lines, { literal = literal })
+        end
+    end
+
+    local within_room_ids = nil
+    if gps_room_element.within_room_ids and table.size(gps_room_element.within_room_ids) > 0 then
+        within_room_ids = {}
+        for _, id in pairs(gps_room_element.within_room_ids) do
+            within_room_ids[tonumber(id)] = true
+        end
+    end
+
+    local area_name = gps_room_element.area_name
+    if area_name == "" then
+        area_name = nil
+    end
+
+    return {
+        id = self:generate_room_gps_id(room_id, index),
+        room_id = tonumber(room_id),
+        lines = lines,
+        area_name = area_name,
+        within_room_ids = within_room_ids
+    }
+end
+
+function amap.gps:index_entry(entry)
+    local last = entry.lines[#entry.lines]
+    if last.literal then
+        local key = words_of(last.literal)[1]
+        if key then
+            local bucket = self.entries_by_word[key]
+            if not bucket then
+                bucket = {}
+                self.entries_by_word[key] = bucket
+            end
+            table.insert(bucket, entry)
+            return
+        end
+    end
+    table.insert(self.scanned_entries, entry)
+end
+
+function amap.gps:line_matches(gps_line, text)
+    if gps_line.literal then
+        return string.find(text, gps_line.literal, 1, true) ~= nil
+    end
+    local ok, result = pcall(rex.find, text, gps_line.pattern)
+    return ok and result ~= nil
+end
+
+--- Walk the entry's lines backwards from the current one. They have to sit directly
+--- behind each other, which is the sequence the per-entry cursor used to enforce.
+function amap.gps:matches_window(entry)
+    local idx = #self.recent
+    for i = #entry.lines, 1, -1 do
+        if idx < 1 or not self:line_matches(entry.lines[i], self.recent[idx]) then
+            return false
+        end
+        idx = idx - 1
+    end
+    return true
+end
+
+function amap.gps:check_context(entry)
+    if entry.area_name and entry.area_name ~= amap.curr.area then
+        -- not in the area of the gps, ending
+        return false
+    end
+    if entry.within_room_ids and not entry.within_room_ids[tonumber(amap.curr.id)] then
+        -- not in the within room ids, ending
+        return false
+    end
+    return true
+end
+
+function amap.gps:try_entry(entry)
+    if self.synced_at_line == self.line_counter then
+        return
+    end
+    if not self:check_context(entry) or not self:matches_window(entry) then
+        return
+    end
+    -- Claim the line even when we are already standing there: a second entry sharing this
+    -- line lost the race, and letting it move us would undo a good sync.
+    self.synced_at_line = self.line_counter
+    if tonumber(amap.curr.id) ~= entry.room_id then
+        amap:set_position(entry.room_id, true)
+        cecho("\n<orange> Map Sync: gps " .. entry.id)
+    end
+end
+
+--- A sequence is recognised when its *final* line arrives and the ones before it are
+--- still in the window, so no entry carries a cursor between lines: nothing can be left
+--- half-open, and a line arriving out of turn cannot desynchronise anything.
+function amap.gps:on_line(text)
+    self.line_counter = self.line_counter + 1
+    table.insert(self.recent, trim5(text))
+    while #self.recent > self.window_size do
+        table.remove(self.recent, 1)
+    end
+
+    for _, entry in ipairs(self.scanned_entries) do
+        self:try_entry(entry)
+    end
+
+    local seen = {}
+    for _, word in ipairs(words_of(self.recent[#self.recent])) do
+        local bucket = self.entries_by_word[word]
+        if bucket then
+            for _, entry in ipairs(bucket) do
+                if not seen[entry] then
+                    seen[entry] = true
+                    self:try_entry(entry)
+                end
             end
         end
     end
-    self.ready = true
-
-    scripts:print_log("Zbudowalem " .. tostring(gps_count) .. " elementow gps\n", true)
 end
 
-function amap.gps:init_trigger(room_id, room_incremental_gps_number, gps_string_lines, line_delta, area_name, within_room_ids)
-    if not room_id or not room_incremental_gps_number or not gps_string_lines then
-        error("map_sync.gps:init_trigger got empty parameters")
-        return
+function amap.gps:init_triggers()
+    self.entries_by_word = {}
+    self.scanned_entries = {}
+    self.recent = {}
+    self.window_size = 1
+    self.synced_at_line = -1
+
+    -- Sorted, so two entries claiming the same line always resolve the same way.
+    local room_ids = {}
+    for id in pairs(getRooms()) do
+        table.insert(room_ids, id)
     end
+    table.sort(room_ids, function(a, b) return tonumber(a) < tonumber(b) end)
 
-    local room_gps_id = self:generate_room_gps_id(room_id, room_incremental_gps_number)
-
-    local calculated_line_delta = table.size(gps_string_lines) - 1
-    if line_delta then
-        calculated_line_delta = tonumber(line_delta) - 1
-    end
-
-    local passable_area_name = ""
-    if area_name and area_name ~= "" then
-        passable_area_name = area_name
-    end
-
-    if within_room_ids and table.size(within_room_ids) > 0 then
-        self.room_id_to_within_room_ids[room_gps_id] = {}
-        for _, room_id in pairs(within_room_ids) do
-            self.room_id_to_within_room_ids[room_gps_id][tonumber(room_id)] = true
+    local gps_count = 0
+    for _, id in ipairs(room_ids) do
+        local room_data_gps = getRoomUserData(id, amap.gps.user_data_gps_key)
+        if room_data_gps and room_data_gps ~= "" then
+            local ok, gps_data = pcall(yajl.to_value, room_data_gps)
+            if ok and type(gps_data) == "table" then
+                for k, v in ipairs(gps_data) do
+                    local entry = self:compile_entry(id, k, v)
+                    if entry then
+                        self:index_entry(entry)
+                        if #entry.lines > self.window_size then
+                            self.window_size = #entry.lines
+                        end
+                        gps_count = gps_count + 1
+                    end
+                end
+            end
         end
     end
 
-    self.room_id_to_gps_lines[room_gps_id] = gps_string_lines
-    self.room_id_to_line_delta[room_gps_id] = calculated_line_delta
-
-    local trigger_exact_line = gps_string_lines[1]
-    local trigger_id = tempExactMatchTrigger(trigger_exact_line, [[ map_sync_gps_first_line_match("]] .. room_id .. [[", "]] .. room_gps_id .. [[", ]] .. calculated_line_delta .. [[, "]] .. passable_area_name .. [[")]])
-    self.trigger_ids[room_gps_id] = trigger_id
-end
-
-function map_sync_gps_first_line_match(room_id, room_gps_id, line_delta, area_name)
-    if area_name and area_name ~= "" and area_name ~= amap.curr.area then
-        -- not in the area of the gps, ending
-        return
-    elseif amap.gps.room_id_to_within_room_ids[room_gps_id] ~= nil and amap.gps.room_id_to_within_room_ids[room_gps_id][tonumber(amap.curr.id)] == nil then
-        -- not in the within room ids, ending
-        return
-    elseif table.size(amap.gps.room_id_to_gps_lines[room_gps_id]) == 1 then
-        -- the gps consists of a single line
-        amap:set_position(room_id, true)
-        cecho("\n<orange> Map Sync: gps " .. room_gps_id)
-    else
-        amap.gps.current_room_id_gps_index[room_gps_id] = 2
-        local temp_line_trigger_id = tempLineTrigger(1, line_delta, [[ map_sync_gps_subsequent_line_check_match("]] .. room_id .. [[", "]] .. room_gps_id .. [[")]])
-        amap.gps.current_room_id_line_trigger_id[room_gps_id] = temp_line_trigger_id
+    -- One trigger for the whole map, kept across rebuilds. The per-entry triggers this
+    -- replaced were never killed, so every rebuild used to leave the old ones running.
+    if not self.line_trigger_id then
+        self.line_trigger_id = tempRegexTrigger("^", function() amap.gps:on_line(line) end)
     end
-end
 
-function map_sync_gps_subsequent_line_check_match(room_id, room_gps_id)
-    local current_line_id = amap.gps.current_room_id_gps_index[room_gps_id]
-    local gps_lines_count = table.size(amap.gps.room_id_to_gps_lines[room_gps_id])
-    local line_matched_trigger = trim5(line) == amap.gps.room_id_to_gps_lines[room_gps_id][current_line_id]
-    if line_matched_trigger and current_line_id == gps_lines_count then
-        -- matched and it is the last line, set gps
-        amap:set_position(room_id, true)
-        cecho("\n<orange> Map Sync: gps " .. room_gps_id)
-    elseif line_matched_trigger then
-        -- matched and line in the middle of multi-line, continuing
-        amap.gps.current_room_id_gps_index[room_gps_id] = amap.gps.current_room_id_gps_index[room_gps_id] + 1
-    else
-        -- didn't match, just kill the line trigger
-        killTrigger(amap.gps.current_room_id_line_trigger_id[room_gps_id])
-    end
+    self.ready = true
+
+    scripts:print_log("Zbudowalem " .. tostring(gps_count) .. " elementow gps\n", true)
 end
 
 function amap.gps:generate_room_gps_id(room_id, room_incremental_gps_number)
@@ -229,13 +404,19 @@ end
 
 function alias_func_map_sync_add_gps()
     if amap.curr.id then
-        amap.gps:add_gps_to_room(amap.curr.id, matches[2], nil, nil, nil)
+        amap.gps:add_gps_to_room(amap.curr.id, matches[2], nil, nil)
+    end
+end
+
+function alias_func_map_sync_add_gps_regex()
+    if amap.curr.id then
+        amap.gps:add_gps_to_room(amap.curr.id, matches[2], nil, nil, true)
     end
 end
 
 function alias_func_map_sync_add_gps_area()
     if amap.curr.id then
-        amap.gps:add_gps_to_room(amap.curr.id, matches[2], nil, amap.curr.area, nil)
+        amap.gps:add_gps_to_room(amap.curr.id, matches[2], amap.curr.area, nil)
     end
 end
 
@@ -243,7 +424,7 @@ function alias_func_map_sync_add_gps_within_rooms()
     local within_room_ids = string.split(matches[2], ",")
 
     if amap.curr.id then
-        amap.gps:add_gps_to_room(amap.curr.id, matches[3], nil, nil, within_room_ids)
+        amap.gps:add_gps_to_room(amap.curr.id, matches[3], nil, within_room_ids)
     end
 end
 


### PR DESCRIPTION
Ta sama przebudowa co po stronie web clienta ([Delwing/arkadia-web-client-extension@ede5e19](https://github.com/Delwing/arkadia-web-client-extension/commit/ede5e191)) i edytora mapy, zeby dane gpsa znaczyly w obu klientach dokladnie to samo.

## Co sie zmienia

**Jeden trigger zamiast setki.** Do tej pory kazdy wpis dostawal `tempExactMatchTrigger`, a po trafieniu pierwszej linii dokladal `tempLineTrigger` z kursorem trzymanym per wpis. Teraz skrypt trzyma okno ostatnich linii (na obecnej mapie: 3) i rozpoznaje wpis, gdy przyjdzie jego **ostatnia** linia, sprawdzajac wczesniejsze w oknie. Nic nie zostaje w polowie otwarte, a linia wtracona przez inny skrypt niczego nie rozjezdza.

Wpisy sa kubelkowane po pierwszym slowie ostatniej linii, wiec linia kosztuje tylko wyszukanie slow, ktore faktycznie zawiera.

**Dopasowanie po fragmencie**, na kazdej linii sekwencji, zamiast `tempExactMatchTrigger`. Piec linii na mapie to urwane wklejki (jedna konczy sie na `... na zachod i ` ze spacja), ktore maja sens wylacznie jako fragment. Literaly sa przycinane przy budowie indeksu.

**Wyrazenia regularne.** Nowy, opcjonalny klucz `gps_line_modes` biegnie rownolegle do `gps_string_lines`; pole z wartoscia `"regex"` robi z tej linii wzorzec (`rex`, PCRE). Z aliasu:

```
/dodaj_gps Kuznia.#re:Sa tutaj [a-z]+ widoczne wyjscia
/dodaj_gps_regex Kuznia w [a-z]+#wyjscia: [a-z]+
```

Dzieki prefiksowi `re:` jeden wpis moze laczyc stala nazwe lokacji ze wzorcem na linie wyjsc, ktora sie zmienia. Wzorzec, ktory sie nie kompiluje, jest odrzucany przy dodawaniu z komunikatem, zamiast po cichu wywalac caly wpis przy wczytywaniu mapy.

**Bez `room_id` i `line_delta`.** Zadne z nich nigdy nie bylo czytane: `init_triggers` zawsze budowal trigger z id lokacji, w ktorej wpis siedzi (jeden wpis na mapie ma tu inna wartosc, przez pomylke), a `tempLineTrigger` byl zabijany na pierwszej niepasujacej linii, wiec sekwencja i tak musiala byc ciagla, cokolwiek mowila delta. Stare wpisy z tymi kluczami wczytuja sie normalnie.

**Przy okazji:** `init_trigger` nigdy nie wolal `killTrigger`, wiec kazda przebudowa zostawiala poprzednie triggery przy zyciu. Teraz jest jeden trigger, tworzony raz. Dodanie i usuniecie gpsa przebudowuje indeks, wiec nowy wpis dziala od razu, bez ponownego otwierania mapy. Jedna linia to najwyzej jedna synchronizacja, i nie ruszamy sie, gdy juz stoimy w tej lokacji.

## Sprawdzone

Nie ma tu frameworka do testow Lua, wiec zbudowalem prowizoryczny harness: zaslepki `getRooms`, `getRoomUserData`, `tempRegexTrigger`, `yajl`, `rex`, `amap`, `cecho`, prawdziwy `mapper/gps.lua` i prawdziwe dane z `mapExport.json`.

- **214 z 214 wpisow z aktualnej mapy** rozpoznaje wlasne linie, okno wychodzi na 3 linie — tyle samo, co w web clientcie.
- 27 asercji na zachowanie: fragment, biale znaki, wzorce, wzorzec nie do skompilowania, przerwana sekwencja, `line_delta` bez wplywu, filtry `area_name` i `within_room_ids`, jedna synchronizacja na linie, numeracja wpisow od 1, oraz sciezka aliasu (`re:` znakuje tylko swoja linie, prefiks jest obcinany, alias nie zapisuje `room_id` ani `line_delta`, wpis dziala natychmiast po dodaniu).
- `Arkadia.xml` przechodzi walidacje wlasnym `Arkadia.xsd` — 0 bledow.

Chetnie dorzuce ten harness do repo osobnym commitem, jesli uznasz, ze warto — bylby to pierwszy uruchamialny test w tym projekcie.

## Do przetestowania recznie

```
/fake Piate nabrzeze.
/fake Wychodzisz na Piate nabrzeze. Wieje wiatr.
```

Obie linie synchronizuja do 7909; druga pokazuje dopasowanie po fragmencie, ktorego stary `tempExactMatchTrigger` by nie zlapal.

```
/fake Schodzisz z okretu.
/fake Pierwsze nabrzeze.
/fake Sa tutaj dwa widoczne wyjscia: poludnie i polnoc.
```

Sekwencja trzyliniowa, synchronizuje do 7911. Wciecie miedzy nie dowolnej innej linii ma nie zsynchronizowac nic.

https://claude.ai/code/session_01BYvwkVFxvHXAz1ovX8ckMM
