### PR TITLE
dodaj wzorzec mozesz_dobywac dla wygasniecia 'rozbrojenia postaci'

### DIFF
--- a/Arkadia.xml
+++ b/Arkadia.xml
@@ -17989,9 +17989,11 @@ scripts.misc.knowledge:stop_reading_library()</script>
 								<regexCodeList>
 									<string>(^[ &gt;]*Bol w (prawej|lewej) dloni staje sie mniej odczuwalny\.$)</string>
 									<string>Nagle czujesz,  jak dziwna sila opanowuje twe czlonki.  Nie jestes w stanie kontrolowac swojego zachowania!</string>
+									<string>Czujesz, ze efekt dzialania czaru 'rozbrojenie postaci' konczy sie i powoli odzyskujesz czucie w swoich dloniach.</string>
 								</regexCodeList>
 								<regexCodePropertyList>
 									<integer>1</integer>
+									<integer>0</integer>
 									<integer>0</integer>
 								</regexCodePropertyList>
 							</Trigger>


### PR DESCRIPTION
Trigger `color_other/mozesz_dobywac` lapal do tej pory tylko wygasniecie wytracenia broni (`Bol w prawej/lewej dloni staje sie mniej odczuwalny.`). Czar `rozbrojenie postaci` konczy sie innym komunikatem, wiec po jego wygasnieciu nie bylo ani dzwieku, ani informacji `[ BRON ] Mozesz dobyc broni`, ani podpiecia klawisza funkcyjnego pod dobycie.

Dodany wzorzec (substring):

```
Czujesz, ze efekt dzialania czaru 'rozbrojenie postaci' konczy sie i powoli odzyskujesz czucie w swoich dloniach.
```

Zmiana tylko w `Arkadia.xml`, bez zmian w lua.

https://claude.ai/code/session_016gaaN6guihjyCLsKKUikMv