### PR TITLE
evaluate gems once per collect run instead of per corpse

### DIFF
--- a/skrypty/inventory/collect.lua
+++ b/skrypty/inventory/collect.lua
@@ -76,8 +76,9 @@ function scripts.inv.collect:key_pressed(force, index, put_into_bag)
             end
         end
         if scripts.inv.collect["current_mode"] == 2 or scripts.inv.collect["current_mode"] == 3 or scripts.inv.collect["current_mode"] == 5 or scripts.inv.collect["current_mode"] == 6 then
-            sendAll("wez kamienie z " .. from, "ocen kamienie", false)
+            sendAll("wez kamienie z " .. from, false)
             if put_into_bag then
+                sendAll("ocen kamienie", false)
                 scripts.inv:put_into_bag({ "kamienie" }, "gems", 1)
             end
         end


### PR DESCRIPTION
**Problem**
When collecting gems from multiple corpses (post-combat collect bind or `/zbierz`), `ocen kamienie` is sent after every corpse. The command evaluates all carried gems, so gems from earlier corpses get evaluated again for each subsequent corpse (e.g. 3 gems from 2 corpses = 5 evaluations). Reported by a player on Discord.

**Change**
- `ocen kamienie` is sent once, after the last corpse (using the same flag that already gates putting gems into the bag).
- Single-corpse collection (`/zb`, `/zb!`) unchanged - still one evaluation.
- This also fixes the same duplicate evaluation in `/zbierz` (shared code path).

**Testing**
Local mocked-environment unit tests (exactly one `ocen kamienie` for 2-3 corpses, single-corpse path, team gem mode) + in-game verification in Mudlet.
