### PR TITLE
widen upiorne bronie gag regexes to match any weapon

### DIFF
--- a/Arkadia.xml
+++ b/Arkadia.xml
@@ -3069,7 +3069,7 @@ scripts.misc.knowledge:stop_reading_library()</script>
 										<colorTriggerBgColor>#000000</colorTriggerBgColor>
 										<regexCodeList>
 											<string>szybkim ciosem upiorn</string>
-											<string>^(?'attacker'.+?) ledwo muska (?'target'.+?) upiornym ciemnym mlotem, trafiajac (?:go|ja) w (?'where'.*)\.$</string>
+											<string>^(?'attacker'.+?) ledwo muska (?'target'.+?) upiornym ciemnym \w+, trafiajac (?:go|ja) w (?'where'.*)\.$</string>
 										</regexCodeList>
 										<regexCodePropertyList>
 											<integer>0</integer>
@@ -3091,7 +3091,7 @@ scripts.misc.knowledge:stop_reading_library()</script>
 										<colorTriggerBgColor>#000000</colorTriggerBgColor>
 										<regexCodeList>
 											<string>gwaltownym uderzeniem upiorn</string>
-											<string>^Gwaltownym wymachem upiornego ciemnego mlota w (?'where'.+?) dosiegasz (?'target'.+?), lekko (?:go|ja) raniac\.$</string>
+											<string>^Gwaltownym wymachem upiornego ciemnego \w+ w (?'where'.+?) dosiegasz (?'target'.+?), lekko (?:go|ja) raniac\.$</string>
 										</regexCodeList>
 										<regexCodePropertyList>
 											<integer>0</integer>


### PR DESCRIPTION
Both weapon-specific patterns in the `upiorne_bronie` gag group were hardcoded to `mlot`, so hits with other *upiorna ciemna* weapons (e.g. chepesz) were not gagged.

- `Arkadia.xml:3072` (`upiorny_1`): `upiornym ciemnym mlotem,` -> `upiornym ciemnym \w+,`
- `Arkadia.xml:3094` (`upiorny_2`): `upiornego ciemnego mlota w` -> `upiornego ciemnego \w+ w`

The group's parent filter is already generic (`upiorn\w+ ciemn\w+`), and the remaining child patterns are plain substrings with no weapon name, so they worked for any weapon already.

Verified with `grep -P` that both regexes match the chepesz lines and still match the original mlot lines; `Arkadia.xml` still parses as valid XML.

https://claude.ai/code/session_01YE8MZgSwXmxKzKw7VXxxh9